### PR TITLE
Introduce the refreshIfNeeded method

### DIFF
--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -107,13 +107,17 @@ public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
     public static func == (lhs: Token, rhs: Token) -> Bool {
         lhs.context == rhs.context &&
         lhs.accessToken == rhs.accessToken &&
-        lhs.scope == rhs.scope
+        lhs.scope == rhs.scope &&
+        lhs.idToken?.rawValue == rhs.idToken?.rawValue &&
+        lhs.deviceSecret == rhs.deviceSecret
     }
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(context)
         hasher.combine(accessToken)
         hasher.combine(scope)
+        hasher.combine(idToken?.rawValue)
+        hasher.combine(deviceSecret)
     }
 
     required init(issuedAt: Date,

--- a/Sources/AuthFoundation/Utilities/Expires.swift
+++ b/Sources/AuthFoundation/Utilities/Expires.swift
@@ -47,5 +47,3 @@ extension Expires {
     
     public var isValid: Bool { !isExpired }
 }
-
-

--- a/Tests/AuthFoundationTests/CredentialRefreshTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRefreshTests.swift
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import TestCommon
+@testable import AuthFoundation
+
+final class CredentialRefreshTests: XCTestCase {
+    let coordinator = MockCredentialCoordinator()
+
+    func credential(for token: Token, expectAPICalls: Bool = true) throws -> Credential {
+        let credential = coordinator.credentialDataSource.credential(for: token, coordinator: coordinator)
+        
+        if expectAPICalls {
+            let urlSession = credential.oauth2.session as! URLSessionMock
+            urlSession.expect("https://example.com/.well-known/openid-configuration",
+                              data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                              contentType: "application/json")
+            urlSession.expect("https://example.com/oauth2/v1/token",
+                              data: try data(from: .module, for: "token", in: "MockResponses"))
+        }
+        
+        return credential
+    }
+    
+    func testRefresh() throws {
+        let credential = try credential(for: Token.simpleMockToken)
+
+        let expect = expectation(description: "refresh")
+        credential.refresh { result in
+            switch result {
+            case .success(let newToken):
+                XCTAssertNotNil(newToken)
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        XCTAssertTrue(credential.token.isRefreshing)
+
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertFalse(credential.token.isRefreshing)
+    }
+
+    func testRefreshIfNeededExpired() throws {
+        let credential = try credential(for: Token.mockToken(issuedOffset: 6000))
+        let expect = expectation(description: "refresh")
+        credential.refreshIfNeeded() { result in
+            switch result {
+            case .success(let newToken):
+                XCTAssertNotNil(newToken)
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        XCTAssertTrue(credential.token.isRefreshing)
+
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertFalse(credential.token.isRefreshing)
+    }
+
+    func testRefreshIfNeededWithinGraceInterval() throws {
+        let credential = try credential(for: Token.mockToken(issuedOffset: 0),
+                                           expectAPICalls: false)
+        let expect = expectation(description: "refresh")
+        credential.refreshIfNeeded() { result in
+            switch result {
+            case .success(let newToken):
+                XCTAssertNotNil(newToken)
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        XCTAssertFalse(credential.token.isRefreshing)
+
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertFalse(credential.token.isRefreshing)
+    }
+
+    func testRefreshIfNeededOutsideGraceInterval() throws {
+        let credential = try credential(for: Token.mockToken(issuedOffset: 3500))
+        let expect = expectation(description: "refresh")
+        credential.refreshIfNeeded() { result in
+            switch result {
+            case .success(let newToken):
+                XCTAssertNotNil(newToken)
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        XCTAssertTrue(credential.token.isRefreshing)
+
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertFalse(credential.token.isRefreshing)
+    }
+
+    #if swift(>=5.5.1)
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    func testRefreshAsync() async throws {
+        let credential = try credential(for: Token.simpleMockToken)
+        let token = try await credential.refresh()
+        XCTAssertNotNil(token)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    func testRefreshIfNeededExpiredAsync() async throws {
+        let credential = try credential(for: Token.mockToken(issuedOffset: 6000))
+        let token = try await credential.refreshIfNeeded()
+        XCTAssertNotNil(token)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    func testRefreshIfNeededWithinGraceIntervalAsync() async throws {
+        let credential = try credential(for: Token.mockToken(issuedOffset: 0),
+                                           expectAPICalls: false)
+        let token = try await credential.refreshIfNeeded()
+        XCTAssertNotNil(token)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    func testRefreshIfNeededOutsideGraceIntervalAsync() async throws {
+            let credential = try credential(for: Token.mockToken(issuedOffset: 3500))
+        let token = try await credential.refreshIfNeeded()
+        XCTAssertNotNil(token)
+    }
+    #endif
+}

--- a/Tests/AuthFoundationTests/CredentialTests.swift
+++ b/Tests/AuthFoundationTests/CredentialTests.swift
@@ -63,44 +63,4 @@ final class CredentialTests: XCTestCase {
         }
     }
     
-    func testRefresh() throws {
-        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
-                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
-                          contentType: "application/json")
-        urlSession.expect("https://example.com/oauth2/v1/token",
-                          data: try data(from: .module, for: "token", in: "MockResponses"))
-        
-        let expect = expectation(description: "refresh")
-        credential.refresh { result in
-            switch result {
-            case .success(let newToken):
-                XCTAssertNotNil(newToken)
-            case .failure(let error):
-                XCTAssertNil(error)
-            }
-            expect.fulfill()
-        }
-        
-        XCTAssertTrue(credential.token.isRefreshing)
-
-        waitForExpectations(timeout: 1.0) { error in
-            XCTAssertNil(error)
-        }
-        
-        XCTAssertFalse(credential.token.isRefreshing)
-    }
-
-    #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
-    func testRefreshAsync() async throws {
-        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
-                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
-                          contentType: "application/json")
-        urlSession.expect("https://example.com/oauth2/v1/token",
-                          data: try data(from: .module, for: "token", in: "MockResponses"))
-        
-        let token = try await credential.refresh()
-        XCTAssertNotNil(token)
-    }
-    #endif
 }

--- a/Tests/AuthFoundationTests/ExpiresTests.swift
+++ b/Tests/AuthFoundationTests/ExpiresTests.swift
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import AuthFoundation
+
+class MockExpires: Expires {
+    var expiresIn: TimeInterval = 60
+    var issuedAt: Date?
+}
+
+final class ExpiresTests: XCTestCase {
+    let expires = MockExpires()
+    
+    override func setUpWithError() throws {
+        DefaultTimeCoordinator.resetToDefault()
+    }
+    
+    func testNullIssueDate() {
+        XCTAssertNil(expires.expiresAt)
+        XCTAssertFalse(expires.isExpired)
+        XCTAssertTrue(expires.isValid)
+    }
+    
+    func testValidTime() {
+        expires.issuedAt = Date()
+        XCTAssertTrue(expires.isValid)
+        XCTAssertFalse(expires.isExpired)
+    }
+
+    func testExpiredTime() {
+        expires.issuedAt = Date(timeIntervalSinceNow: -300)
+        XCTAssertFalse(expires.isValid)
+        XCTAssertTrue(expires.isExpired)
+    }
+}

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+@testable import AuthFoundation
+
+extension Token {
+    static let mockContext = Token.Context(
+        configuration: OAuth2Client.Configuration(
+            baseURL: URL(string: "https://example.com")!,
+            clientId: "0oa3en4fIMQ3ddc204w5",
+            scopes: "offline_access profile openid"),
+        clientSettings: [ "client_id": "0oa3en4fIMQ3ddc204w5" ])
+
+    static let simpleMockToken = mockToken()
+    
+    static func mockToken(issuedOffset: TimeInterval = 0) -> Token {
+        Token(issuedAt: Date(timeIntervalSinceNow: -issuedOffset),
+              tokenType: "Bearer",
+              expiresIn: 3600,
+              accessToken: JWT.mockAccessToken,
+              scope: "openid",
+              refreshToken: nil,
+              idToken: try? JWT(JWT.mockIDToken),
+              deviceSecret: nil,
+              context: mockContext)
+    }
+}


### PR DESCRIPTION
This also adds unit tests around the `Expires` protocol, which can be used to determine if a user is logged in (e.g. `credential.token.isValid` or `credential.token.isExpired`)