### PR TITLE
Add unique ID for tokens, and associated metadata

### DIFF
--- a/.github/workflows/okta-mobile.yaml
+++ b/.github/workflows/okta-mobile.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Unit Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:

--- a/.github/workflows/okta-mobile.yaml
+++ b/.github/workflows/okta-mobile.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest]
     steps:
     - name: Get swift version
       run: swift --version

--- a/.github/workflows/okta-mobile.yaml
+++ b/.github/workflows/okta-mobile.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest, ubuntu-latest]
     steps:
     - name: Get swift version
       run: swift --version

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ import WebAuthenticationUI
 
 func signIn() async {
     let token = try await WebAuthentication.signIn(from: view.window)
-    let credential = Credential.for(token: token)
+    let credential = try Credential.store(token)
 }
 ```
 

--- a/Sources/AuthFoundation/JWT/Internal/DefaultAccessTokenValidator.swift
+++ b/Sources/AuthFoundation/JWT/Internal/DefaultAccessTokenValidator.swift
@@ -17,11 +17,12 @@ import CommonCrypto
 #endif
 
 struct DefaultAccessTokenValidator: AccessTokenValidator {
+    #if !canImport(CommonCrypto)
     func validate(accessToken: String, idToken: JWT) throws {
-        #if !canImport(CommonCrypto)
         throw JWTError.signatureVerificationUnavailable
-        #endif
-
+    }
+    #else
+    func validate(accessToken: String, idToken: JWT) throws {
         guard let atHash = idToken.value(String.self, for: "at_hash")
         else {
             return
@@ -46,4 +47,5 @@ struct DefaultAccessTokenValidator: AccessTokenValidator {
             throw JWTError.signatureInvalid
         }
     }
+    #endif
 }

--- a/Sources/AuthFoundation/Requests/Token+Requests.swift
+++ b/Sources/AuthFoundation/Requests/Token+Requests.swift
@@ -98,6 +98,10 @@ extension Token.RefreshRequest: OAuth2APIRequest, APIRequestBody, APIParsingCont
             guard let key = CodingUserInfoKey(rawValue: item.key) else { return }
             partialResult?[key] = item.value
         }) else { return nil }
-        return [ .clientSettings: settings ]
+        
+        return [
+            .clientSettings: settings,
+            .tokenId: token.id
+        ]
     }
 }

--- a/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
@@ -127,7 +127,7 @@ class KeychainTokenStorage: TokenStorage {
         delegate?.token(storage: self, removed: id)
 
         if defaultTokenID == id {
-            try setDefaultTokenID(id)
+            try setDefaultTokenID(nil)
         }
     }
     

--- a/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
@@ -63,6 +63,7 @@ class UserDefaultsTokenStorage: TokenStorage {
             userDefaults.removeObject(forKey: UserDefaultsKeys.defaultTokenKey)
         }
         userDefaults.synchronize()
+        delegate?.token(storage: self, defaultChanged: id)
     }
     
     var allIDs: [UUID] {

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -16,18 +16,21 @@ public enum TokenError: Error {
     case tokenTypeMissing(_: Token.RevokeType)
     case refreshTokenMissing
     case contextMissing
-    case tokenNotFound(_: Token)
+    case tokenNotFound(id: UUID)
     case cannotReplaceToken
     case duplicateTokenAdded
 }
 
 /// Token information representing a user's access to a resource server, including access token, refresh token, and other related information.
-public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
+public class Token: Codable, Equatable, Hashable, Expires, Identifiable {
     public static var idTokenValidator: IDTokenValidator = DefaultIDTokenValidator()
     public static var accessTokenValidator: AccessTokenValidator = DefaultAccessTokenValidator()
-
+    
+    /// The unique identifier for this token.
+    public internal(set) var id: UUID
+    
     // The date this token was issued at.
-    public var issuedAt: Date?
+    public let issuedAt: Date?
     
     /// The string type of the token (e.g. `Bearer`).
     public let tokenType: String
@@ -57,24 +60,6 @@ public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
         refreshAction != nil
     }
     
-    public typealias ID = String
-    public lazy var id: String = {
-        if let jwt = try? JWT(accessToken),
-           let cid: String = jwt[.clientId],
-           let uid: String = jwt[.userId]
-        {
-            return "\(cid).\(uid)"
-        }
-        
-        if let idToken = idToken,
-           let subject = idToken.subject
-        {
-            return subject
-        }
-
-        return UUID().uuidString
-    }()
-
     internal var refreshAction: CoalescedResult<Result<Token, OAuth2Error>>?
 
     /// Return the relevant token string for the given type.
@@ -123,7 +108,8 @@ public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
         hasher.combine(deviceSecret)
     }
 
-    required init(issuedAt: Date,
+    required init(id: UUID,
+                  issuedAt: Date,
                   tokenType: String,
                   expiresIn: TimeInterval,
                   accessToken: String,
@@ -133,6 +119,7 @@ public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
                   deviceSecret: String?,
                   context: Context)
     {
+        self.id = id
         self.issuedAt = issuedAt
         self.tokenType = tokenType
         self.expiresIn = expiresIn
@@ -156,13 +143,23 @@ public class Token: Codable, Equatable, Hashable, Identifiable, Expires {
         } else {
             throw TokenError.contextMissing
         }
-        
+
+        let id: UUID
+        if let userInfoId = decoder.userInfo[.tokenId] as? UUID {
+            id = userInfoId
+        } else if container.contains(.id) {
+            id = try container.decode(UUID.self, forKey: .id)
+        } else {
+            id = UUID()
+        }
+
         var idToken: JWT? = nil
         if let idTokenString = try container.decodeIfPresent(String.self, forKey: .idToken) {
             idToken = try JWT(idTokenString)
         }
         
-        self.init(issuedAt: Date.nowCoordinated,
+        self.init(id: id,
+                  issuedAt: Date.nowCoordinated,
                   tokenType: try container.decode(String.self, forKey: .tokenType),
                   expiresIn: try container.decode(TimeInterval.self, forKey: .expiresIn),
                   accessToken: try container.decode(String.self, forKey: .accessToken),
@@ -205,6 +202,7 @@ extension Token {
 
 extension Token {
     enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
         case issuedAt
         case tokenType
         case expiresIn
@@ -218,6 +216,7 @@ extension Token {
 }
 
 extension CodingUserInfoKey {
+    public static let tokenId = CodingUserInfoKey(rawValue: "tokenId")!
     public static let apiClientConfiguration = CodingUserInfoKey(rawValue: "apiClientConfiguration")!
     public static let clientSettings = CodingUserInfoKey(rawValue: "clientSettings")!
 }

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -16,7 +16,7 @@ public enum TokenError: Error {
     case tokenTypeMissing(_: Token.RevokeType)
     case refreshTokenMissing
     case contextMissing
-    case tokenNotFound(id: UUID)
+    case tokenNotFound(id: String)
     case cannotReplaceToken
     case duplicateTokenAdded
 }
@@ -27,7 +27,7 @@ public class Token: Codable, Equatable, Hashable, Expires, Identifiable {
     public static var accessTokenValidator: AccessTokenValidator = DefaultAccessTokenValidator()
     
     /// The unique identifier for this token.
-    public internal(set) var id: UUID
+    public internal(set) var id: String
     
     // The date this token was issued at.
     public let issuedAt: Date?
@@ -108,7 +108,7 @@ public class Token: Codable, Equatable, Hashable, Expires, Identifiable {
         hasher.combine(deviceSecret)
     }
 
-    required init(id: UUID,
+    required init(id: String,
                   issuedAt: Date,
                   tokenType: String,
                   expiresIn: TimeInterval,
@@ -144,13 +144,13 @@ public class Token: Codable, Equatable, Hashable, Expires, Identifiable {
             throw TokenError.contextMissing
         }
 
-        let id: UUID
-        if let userInfoId = decoder.userInfo[.tokenId] as? UUID {
+        let id: String
+        if let userInfoId = decoder.userInfo[.tokenId] as? String {
             id = userInfoId
         } else if container.contains(.id) {
-            id = try container.decode(UUID.self, forKey: .id)
+            id = try container.decode(String.self, forKey: .id)
         } else {
-            id = UUID()
+            id = UUID().uuidString
         }
 
         var idToken: JWT? = nil

--- a/Sources/AuthFoundation/Token Management/TokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/TokenStorage.swift
@@ -26,61 +26,61 @@ public protocol TokenStorage {
     /// > Note: Setting a new token should implicitly invoke ``add(token:)`` if the token doesn't previously exist within storage.
     /// >
     /// > The ``TokenStorageDelegate/token(storage:defaultChanged:)`` method should also be invoked.
-    var defaultTokenID: UUID? { get }
+    var defaultTokenID: String? { get }
 
-    func setDefaultTokenID(_ id: UUID?) throws
+    func setDefaultTokenID(_ id: String?) throws
 
     /// Returns all tokens currently in storage.
-    var allIDs: [UUID] { get }
+    var allIDs: [String] { get }
     
     /// Adds the given token.
     ///
     /// This should throw ``TokenError/duplicateTokenAdded`` if the token already exists in storage.
     ///
     /// > Note: This method should invoke the ``TokenStorageDelegate/token(storage:added:)`` delegate method.
-    func add(token: Token, with id: UUID) throws
+    func add(token: Token, with id: String) throws
     
     /// Associates the given metadata with the token identified by the given ID.
-    func assign(metadata: [String:String], for id: UUID) throws
+    func setMetadata(_ metadata: [String:String], for id: String) throws
     
     /// Returns the metadata for the given token ID.
     /// - Returns: Metadata for this token ID.
-    func metadata(for id: UUID) throws -> [String:String]
+    func metadata(for id: String) throws -> [String:String]
     
     /// Replaces an existing token with a new one.
     ///
     /// This can be used during the token refresh process, and indicates that one token is semantically the same as another. If the token being replaced is the default, the default value should be updated as well.
     ///
     /// > Note: This method should invoke the ``TokenStorageDelegate/token(storage:replaced:with:)`` and ``TokenStorageDelegate/token(storage:defaultChanged:)`` methods as needed.
-    func replace(token id: UUID, with token: Token) throws
+    func replace(token id: String, with token: Token) throws
 
     /// Removes the given token.
     ///
     /// > Note: This method should invoke the  ``TokenStorageDelegate/token(storage:removed:)`` method.
-    func remove(id: UUID) throws
+    func remove(id: String) throws
     
-    /// Returns a token for the given UUID.
-    /// - Returns: Token that matches the given UUID.
-    func get(token id: UUID) throws -> Token
+    /// Returns a token for the given ID.
+    /// - Returns: Token that matches the given ID.
+    func get(token id: String) throws -> Token
 }
 
 /// Protocol that custom ``TokenStorage`` instances are required to communicate changes to.
 public protocol TokenStorageDelegate: AnyObject {
     /// Sent when the default token has been changed.
-    func token(storage: TokenStorage, defaultChanged id: UUID?)
+    func token(storage: TokenStorage, defaultChanged id: String?)
     
     /// Sent when a new token has been added.
     ///
     /// > Important: This message should only be sent when a token is actually new. If the token is semantically identical to another one already in storage, the ``token(storage:replaced:with:)`` message should be sent instead.
-    func token(storage: TokenStorage, added id: UUID, token: Token)
+    func token(storage: TokenStorage, added id: String, token: Token)
     
     /// Sent when a token has been removed from storage.
-    func token(storage: TokenStorage, removed id: UUID)
+    func token(storage: TokenStorage, removed id: String)
     
     /// Sent when a token has been updated within storage.
     ///
     /// There are circumstances when a token that already exists within storage needs to be replaced or updated. For example, when a token is refreshed, even though the new token differs, it represents the same resources and capabilities as the previous token.
     ///
     /// As a result, this message is used to convey that a token has been updated, but not removed or newly added.
-    func token(storage: TokenStorage, replaced id: UUID, from oldToken: Token, to newToken: Token)
+    func token(storage: TokenStorage, replaced id: String, from oldToken: Token, to newToken: Token)
 }

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -51,7 +51,7 @@ public class Credential {
     }
     
     /// Lists all users currently stored within the user's application.
-    public static var allCredentials: [Credential] { coordinator.allCredentials }
+    public static var allIDs: [UUID] { coordinator.allIDs }
     
     /// The default grace interval used when refreshing tokens using ``Credential/refreshIfNeeded(graceInterval:completion:)`` or ``Credential/refreshIfNeeded(graceInterval:)``.
     ///
@@ -63,11 +63,46 @@ public class Credential {
     /// If a credential has previously been created for the given token, that cached instance will be returned.
     /// - Parameter token: Token to identify the user by.
     /// - Returns: Credential object that represents the given token.
-    public static func `for`(token: Token) -> Credential { coordinator.for(token: token) }
+    public static func with(token: Token) throws -> Credential {
+        try coordinator.with(token: token)
+    }
+    
+    @discardableResult
+    public static func store(token: Token, metadata: [String:String] = [:]) throws -> Credential {
+        try coordinator.store(token: token, metadata: metadata)
+    }
     
     /// OAuth2 client for performing operations related to the user's token.
     public let oauth2: OAuth2Client
-
+    
+    /// The ID the token is identified by within storage.
+    public lazy var id: UUID = { token.id }()
+    
+    /// The metadata associated with this credential.
+    ///
+    /// This property can be used to associate application-specific information with a ``Token``. This can be used to identify which token should be associated with certain parts of your application.
+    ///
+    /// > Important: Errors thrown from the setter are silently ignored. If you would like to handle errors when changing metadata, see the ``set(metadata:)`` function.
+    public var metadata: [String:String] {
+        get { _metadata }
+        set {
+            try? update(metadata: newValue)
+            _metadata = metadata
+        }
+    }
+    
+    /// Updates the metadata associated with this credential.
+    ///
+    /// This is used internally by the ``metadata`` setter, except the use of this function allows you to catch errors.
+    /// - Parameter metadata: Metadata to set.
+    public func update(metadata: [String:String]) throws {
+        guard let coordinator = coordinator else {
+            throw CredentialError.missingCoordinator
+        }
+     
+        try coordinator.tokenStorage.assign(metadata: metadata, for: token.id)
+    }
+    
     /// The token this credential represents.
     @TimeSensitive<Token>
     public private(set) var token: Token
@@ -97,7 +132,8 @@ public class Credential {
     public convenience init(token: Token) {
         let urlSession = type(of: self).credentialDataSource.urlSession(for: token)
         self.init(token: token,
-                  oauth2: OAuth2Client(token.context.configuration, session: urlSession),
+                  oauth2: OAuth2Client(token.context.configuration,
+                                       session: urlSession),
                   coordinator: Credential.coordinator)
     }
     
@@ -112,7 +148,9 @@ public class Credential {
             throw CredentialError.incorrectClientConfiguration
         }
         
-        self.init(token: token, oauth2: client, coordinator: Credential.coordinator)
+        self.init(token: token,
+                  oauth2: client,
+                  coordinator: Credential.coordinator)
     }
     
     init(token: Token, oauth2 client: OAuth2Client, coordinator: CredentialCoordinator) {
@@ -131,6 +169,14 @@ public class Credential {
     fileprivate static let coordinator = CredentialCoordinatorImpl()
     internal weak var coordinator: CredentialCoordinator?
 
+    private lazy var _metadata: [String:String] = {
+        if let metadata = try? coordinator?.tokenStorage.metadata(for: token.id) {
+            return metadata
+        }
+        
+        return [:]
+    }()
+    
     private(set) internal var automaticRefreshTimer: DispatchSourceTimer?
     private func startAutomaticRefresh() {
         guard let timerSource = createAutomaticRefreshTimer() else { return }

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -51,7 +51,7 @@ public class Credential {
     }
     
     /// Lists all users currently stored within the user's application.
-    public static var allIDs: [UUID] { coordinator.allIDs }
+    public static var allIDs: [String] { coordinator.allIDs }
     
     /// The default grace interval used when refreshing tokens using ``Credential/refreshIfNeeded(graceInterval:completion:)`` or ``Credential/refreshIfNeeded(graceInterval:)``.
     ///
@@ -76,7 +76,7 @@ public class Credential {
     public let oauth2: OAuth2Client
     
     /// The ID the token is identified by within storage.
-    public lazy var id: UUID = { token.id }()
+    public lazy var id: String = { token.id }()
     
     /// The metadata associated with this credential.
     ///
@@ -100,7 +100,7 @@ public class Credential {
             throw CredentialError.missingCoordinator
         }
      
-        try coordinator.tokenStorage.assign(metadata: metadata, for: token.id)
+        try coordinator.tokenStorage.setMetadata(metadata, for: token.id)
     }
     
     /// The token this credential represents.

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinator.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinator.swift
@@ -45,17 +45,17 @@ class CredentialCoordinatorImpl: CredentialCoordinator {
         }
     }
     
-    public var allIDs: [UUID] {
+    public var allIDs: [String] {
         tokenStorage.allIDs
     }
     
     func store(token: Token, metadata: [String:String] = [:]) throws -> Credential {
         try tokenStorage.add(token: token, with: token.id)
-        try tokenStorage.assign(metadata: metadata, for: token.id)
+        try tokenStorage.setMetadata(metadata, for: token.id)
         return credentialDataSource.credential(for: token, coordinator: self)
     }
     
-    func with(id: UUID) throws -> Credential? {
+    func with(id: String) throws -> Credential? {
         credentialDataSource.credential(for: try tokenStorage.get(token: id),
                                         coordinator: self)
     }
@@ -155,7 +155,7 @@ extension CredentialCoordinatorImpl: OAuth2ClientDelegate {
 }
 
 extension CredentialCoordinatorImpl: TokenStorageDelegate {
-    func token(storage: TokenStorage, defaultChanged id: UUID?) {
+    func token(storage: TokenStorage, defaultChanged id: String?) {
         guard _default?.id != id else { return }
 
         if let id = id,
@@ -170,13 +170,13 @@ extension CredentialCoordinatorImpl: TokenStorageDelegate {
                                         object: _default)
     }
     
-    func token(storage: TokenStorage, added id: UUID, token: Token) {
+    func token(storage: TokenStorage, added id: String, token: Token) {
     }
     
-    func token(storage: TokenStorage, removed id: UUID) {
+    func token(storage: TokenStorage, removed id: String) {
     }
     
-    func token(storage: TokenStorage, replaced id: UUID, from oldToken: Token, to newToken: Token) {
+    func token(storage: TokenStorage, replaced id: String, from oldToken: Token, to newToken: Token) {
         guard credentialDataSource.hasCredential(for: oldToken) else { return }
         
         // Doing nothing with this, for now...

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinator.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinator.swift
@@ -27,32 +27,50 @@ class CredentialCoordinatorImpl: CredentialCoordinator {
         didSet {
             tokenStorage.delegate = self
             
-            if let defaultToken = tokenStorage.defaultToken {
-                _default = credentialDataSource.credential(for: defaultToken, coordinator: self)
-            } else {
-                _default = nil
-            }
+            _default = try? CredentialCoordinatorImpl.defaultCredential(
+                tokenStorage: tokenStorage,
+                credentialDataSource: credentialDataSource,
+                coordinator: self)
         }
     }
         
     private var _default: Credential?
     var `default`: Credential? {
         get { _default }
-        set { tokenStorage.defaultToken = newValue?.token }
+        set {
+            if let token = newValue?.token {
+                try? tokenStorage.add(token: token, with: token.id)
+            }
+            try? tokenStorage.setDefaultTokenID(newValue?.id)
+        }
     }
     
-    public var allCredentials: [Credential] {
-        tokenStorage.allTokens.map { credentialDataSource.credential(for: $0, coordinator: self) }
+    public var allIDs: [UUID] {
+        tokenStorage.allIDs
     }
+    
+    func store(token: Token, metadata: [String:String] = [:]) throws -> Credential {
+        try tokenStorage.add(token: token, with: token.id)
+        try tokenStorage.assign(metadata: metadata, for: token.id)
+        return credentialDataSource.credential(for: token, coordinator: self)
+    }
+    
+    func with(id: UUID) throws -> Credential? {
+        credentialDataSource.credential(for: try tokenStorage.get(token: id),
+                                        coordinator: self)
+    }
+    
+    func with(token: Token) throws -> Credential {
+        if !tokenStorage.allIDs.contains(token.id) {
+            try tokenStorage.add(token: token, with: token.id)
+        }
 
-    func `for`(token: Token) -> Credential {
-        try? tokenStorage.add(token: token)
         return credentialDataSource.credential(for: token, coordinator: self)
     }
     
     func remove(credential: Credential) throws {
         credentialDataSource.remove(credential: credential)
-        try tokenStorage.remove(token: credential.token)
+        try tokenStorage.remove(id: credential.id)
     }
     
     static func defaultTokenStorage() -> TokenStorage {
@@ -67,6 +85,17 @@ class CredentialCoordinatorImpl: CredentialCoordinator {
         DefaultCredentialDataSource()
     }
     
+    static func defaultCredential(tokenStorage: TokenStorage,
+                                  credentialDataSource: CredentialDataSource,
+                                  coordinator: CredentialCoordinator) throws -> Credential?
+    {
+        if let defaultTokenId = tokenStorage.defaultTokenID {
+            let token = try tokenStorage.get(token: defaultTokenId)
+            return credentialDataSource.credential(for: token, coordinator: coordinator)
+        }
+        return nil
+    }
+    
     init(tokenStorage: TokenStorage = defaultTokenStorage(),
          credentialDataSource: CredentialDataSource = defaultCredentialDataSource())
     {
@@ -76,10 +105,11 @@ class CredentialCoordinatorImpl: CredentialCoordinator {
         self.credentialDataSource.delegate = self
         self.tokenStorage.delegate = self
 
-        if let defaultToken = tokenStorage.defaultToken {
-            _default = credentialDataSource.credential(for: defaultToken, coordinator: self)
-        }
-        
+        _default = try? CredentialCoordinatorImpl.defaultCredential(
+            tokenStorage: tokenStorage,
+            credentialDataSource: credentialDataSource,
+            coordinator: self)
+
         self.observer = NotificationCenter
             .default
             .addObserver(forName: .oauth2ClientCreated,
@@ -117,7 +147,7 @@ extension CredentialCoordinatorImpl: OAuth2ClientDelegate {
         }
 
         do {
-            try tokenStorage.replace(token: token, with: newToken)
+            try tokenStorage.replace(token: token.id, with: newToken)
         } catch {
             print("Error happened refreshing: \(error)")
         }
@@ -125,10 +155,12 @@ extension CredentialCoordinatorImpl: OAuth2ClientDelegate {
 }
 
 extension CredentialCoordinatorImpl: TokenStorageDelegate {
-    func token(storage: TokenStorage, defaultChanged token: Token?) {
-        guard _default?.token != token else { return }
+    func token(storage: TokenStorage, defaultChanged id: UUID?) {
+        guard _default?.id != id else { return }
 
-        if let token = token {
+        if let id = id,
+           let token = try? storage.get(token: id)
+        {
             _default = credentialDataSource.credential(for: token, coordinator: self)
         } else {
             _default = nil
@@ -138,13 +170,13 @@ extension CredentialCoordinatorImpl: TokenStorageDelegate {
                                         object: _default)
     }
     
-    func token(storage: TokenStorage, added token: Token?) {
+    func token(storage: TokenStorage, added id: UUID, token: Token) {
     }
     
-    func token(storage: TokenStorage, removed token: Token?) {
+    func token(storage: TokenStorage, removed id: UUID) {
     }
     
-    func token(storage: TokenStorage, replaced oldToken: Token, with newToken: Token) {
+    func token(storage: TokenStorage, replaced id: UUID, from oldToken: Token, to newToken: Token) {
         guard credentialDataSource.hasCredential(for: oldToken) else { return }
         
         // Doing nothing with this, for now...

--- a/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
+++ b/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
@@ -24,7 +24,7 @@ final class UserCoordinatorTests: XCTestCase {
     var storage: UserDefaultsTokenStorage!
     var coordinator: CredentialCoordinatorImpl!
     
-    let token = Token(id: UUID(),
+    let token = Token(id: "TokenId",
                       issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,

--- a/Tests/AuthFoundationTests/CredentialTests.swift
+++ b/Tests/AuthFoundationTests/CredentialTests.swift
@@ -19,7 +19,8 @@ final class CredentialTests: XCTestCase {
     var credential: Credential!
     var urlSession: URLSessionMock!
 
-    let token = Token(issuedAt: Date(),
+    let token = Token(id: UUID(),
+                      issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,
                       accessToken: "abcd123",

--- a/Tests/AuthFoundationTests/CredentialTests.swift
+++ b/Tests/AuthFoundationTests/CredentialTests.swift
@@ -19,7 +19,7 @@ final class CredentialTests: XCTestCase {
     var credential: Credential!
     var urlSession: URLSessionMock!
 
-    let token = Token(id: UUID(),
+    let token = Token(id: "TokenId",
                       issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,

--- a/Tests/AuthFoundationTests/DefaultCredentialDataSourceTests.swift
+++ b/Tests/AuthFoundationTests/DefaultCredentialDataSourceTests.swift
@@ -55,7 +55,8 @@ final class DefaultCredentialDataSourceTests: XCTestCase {
     func testCredentials() throws {
         XCTAssertEqual(dataSource.credentialCount, 0)
         
-        let token = Token(issuedAt: Date(),
+        let token = Token(id: UUID(),
+                          issuedAt: Date(),
                           tokenType: "Bearer",
                           expiresIn: 300,
                           accessToken: "abcd123",

--- a/Tests/AuthFoundationTests/DefaultCredentialDataSourceTests.swift
+++ b/Tests/AuthFoundationTests/DefaultCredentialDataSourceTests.swift
@@ -55,7 +55,7 @@ final class DefaultCredentialDataSourceTests: XCTestCase {
     func testCredentials() throws {
         XCTAssertEqual(dataSource.credentialCount, 0)
         
-        let token = Token(id: UUID(),
+        let token = Token(id: "TokenId",
                           issuedAt: Date(),
                           tokenType: "Bearer",
                           expiresIn: 300,

--- a/Tests/AuthFoundationTests/KeychainTokenStorageTests.swift
+++ b/Tests/AuthFoundationTests/KeychainTokenStorageTests.swift
@@ -20,7 +20,8 @@ final class KeychainTokenStorageTests: XCTestCase {
     let mock = MockKeychain()
     var storage: KeychainTokenStorage!
     
-    let token = Token(issuedAt: Date(),
+    let token = Token(id: UUID(),
+                      issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,
                       accessToken:  "eyJraWQiOiJrNkhOMkRLb2sta0V4akpHQkxxZ3pCeU1Dbk4xUnZ6RU9BLTF1a1RqZXhBIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFUNTZqYXNkZmxNY1p5TnkxVmk2cnprTEIwbHEyYzBsSHFFSjhwSGN0NHV6aWxhazAub2FyOWVhenlMakFtNm13Wkc0dzQiLCJpc3MiOiJodHRhczovL2V4YW1wbGUub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNjQyNTMyNTYyLCJleHAiOjE2NDI1MzYxNjIsImNpZCI6IjBvYTNlbjRmSTVhM2RkYzIwNHc1IiwidWlkIjoiMDB1MnE1UTRhY1ZPWG9TYzA0dzUiLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJwcm9maWxlIiwib3BlbmlkIl0sInN1YiI6InNhbXBsZS51c2VyQG9rdGEuY29tIn0.MmpfvhZ8-abO9H74cetD3jj-RCptYGqeVAAs5UH9jrQWSub3X6a4ewqXXPNvgtAeuJBJSpXPIiG9cz4aDWbBmcddQQQzpqjw-BxGdRMnu4fPPJ9kbGJXSHZls7fDFHWBX71D_JTyrSzm_psoI9nQURTre-PyQvWiZIgbJE2WIqKiRECAg-VN85bU57iM3863LD97jpY6-i2ekApQLNOAjScomJTzk8NRH0SoFh17gbV-RQL_T5cIYOtQIlua79k9_F1i_36q5wfqB_tvZwpRua1xIN3zeOwVupfGPz7k-2iQvnMVoN9gOa8mLlFnK_89zJlisLhQBM4BuW1cY2EplA",
@@ -50,14 +51,21 @@ final class KeychainTokenStorageTests: XCTestCase {
         mock.expect(errSecSuccess, result: [] as CFArray)
         mock.expect(noErr)
         mock.expect(noErr)
-        storage.defaultToken = token
-        XCTAssertEqual(mock.operations.count, 6)
+        
+        // Compare existing defaultTokenID
+        mock.expect(errSecSuccess, result: [] as CFArray)
+        
+        // Save new defaultTokenID
+        mock.expect(noErr)
+        mock.expect(noErr)
+        try storage.add(token: token, with: token.id)
+        XCTAssertEqual(mock.operations.count, 7)
         
         // Adding the new token
         // - Searching for tokens matching the same ID
         XCTAssertEqual(mock.operations[0].action, .copy)
         XCTAssertEqual(mock.operations[0].query["svce"] as? String, KeychainTokenStorage.serviceName)
-        XCTAssertEqual(mock.operations[0].query["acct"] as? String, token.id)
+        XCTAssertEqual(mock.operations[0].query["acct"] as? String, token.id.uuidString)
         XCTAssertEqual(mock.operations[0].query["m_Limit"] as? String, "m_LimitAll")
 
         // - Checking how many tokens are already registered
@@ -68,54 +76,59 @@ final class KeychainTokenStorageTests: XCTestCase {
 
         // - Preemptively deleting the newly-added token
         XCTAssertEqual(mock.operations[2].action, .delete)
-        XCTAssertEqual(mock.operations[2].query["acct"] as? String, token.id)
+        XCTAssertEqual(mock.operations[2].query["acct"] as? String, token.id.uuidString)
         XCTAssertEqual(mock.operations[2].query["svce"] as? String, KeychainTokenStorage.serviceName)
 
         // - Adding the new token
         XCTAssertEqual(mock.operations[3].action, .add)
-        XCTAssertEqual(mock.operations[3].query["acct"] as? String, token.id)
+        XCTAssertEqual(mock.operations[3].query["acct"] as? String, token.id.uuidString)
         XCTAssertEqual(mock.operations[3].query["svce"] as? String, KeychainTokenStorage.serviceName)
         let tokenQuery = mock.operations[3].query
         
-        // Deleting the current default key
-        XCTAssertEqual(mock.operations[4].action, .delete)
+        // - Loading the current defaultTokenID
+        XCTAssertEqual(mock.operations[4].action, .copy)
+        XCTAssertNil(mock.operations[4].query["svce"] as? String)
         XCTAssertEqual(mock.operations[4].query["acct"] as? String, KeychainTokenStorage.defaultTokenName)
+        XCTAssertEqual(mock.operations[4].query["m_Limit"] as? String, "m_LimitOne")
+
+        // Deleting the current default key
+        XCTAssertEqual(mock.operations[5].action, .delete)
+        XCTAssertEqual(mock.operations[5].query["acct"] as? String, KeychainTokenStorage.defaultTokenName)
         
         // Adding the new default token ID
-        XCTAssertEqual(mock.operations[5].action, .add)
-        XCTAssertEqual(mock.operations[5].query["acct"] as? String, KeychainTokenStorage.defaultTokenName)
-        XCTAssertEqual(mock.operations[5].query["v_Data"] as? Data, token.id.data(using: .utf8))
+        XCTAssertEqual(mock.operations[6].action, .add)
+        XCTAssertEqual(mock.operations[6].query["acct"] as? String, KeychainTokenStorage.defaultTokenName)
+        XCTAssertEqual(mock.operations[6].query["v_Data"] as? Data, token.id.uuidString.data(using: .utf8))
 
-        XCTAssertEqual(storage.defaultToken, token)
-        XCTAssertTrue(storage.contains(token: token))
+        XCTAssertEqual(storage.defaultTokenID, token.id)
         
         var tokenResult = tokenQuery as! [String:Any?]
         tokenResult["mdat"] = Date()
         tokenResult["cdat"] = Date()
         mock.reset()
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertEqual(storage.allTokens.count, 1)
+        XCTAssertEqual(storage.allIDs.count, 1)
 
         mock.reset()
         mock.expect(noErr, result: tokenResult as CFDictionary)
         mock.expect(noErr)
 
-        storage.defaultToken = nil
-        XCTAssertNil(storage.defaultToken)
+        try storage.setDefaultTokenID(nil)
+        XCTAssertNil(storage.defaultTokenID)
 
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertEqual(storage.allTokens.count, 1)
+        XCTAssertEqual(storage.allIDs.count, 1)
 
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertThrowsError(try storage.add(token: token))
+        XCTAssertThrowsError(try storage.add(token: token, with: token.id))
 
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertEqual(storage.allTokens.count, 1)
+        XCTAssertEqual(storage.allIDs.count, 1)
     }
 
     func testImplicitDefaultToken() throws {
         mock.expect(errSecSuccess, result: [] as CFArray)
-        XCTAssertNil(storage.defaultToken)
+        XCTAssertNil(storage.defaultTokenID)
 
         mock.reset()
         mock.expect(errSecSuccess, result: [] as CFArray)
@@ -125,7 +138,7 @@ final class KeychainTokenStorageTests: XCTestCase {
         mock.expect(noErr)
         mock.expect(noErr)
 
-        XCTAssertNoThrow(try storage.add(token: token))
+        XCTAssertNoThrow(try storage.add(token: token, with: token.id))
 
         let tokenQuery = mock.operations[3].query
         var tokenResult = tokenQuery as! [String:Any?]
@@ -133,9 +146,9 @@ final class KeychainTokenStorageTests: XCTestCase {
         tokenResult["cdat"] = Date()
 
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertEqual(storage.allTokens.count, 1)
+        XCTAssertEqual(storage.allIDs.count, 1)
 
-        XCTAssertEqual(storage.defaultToken, token)
+        XCTAssertEqual(storage.defaultTokenID, token.id)
     }
 
     func testRemoveDefaultToken() throws {
@@ -143,8 +156,11 @@ final class KeychainTokenStorageTests: XCTestCase {
         mock.expect(errSecSuccess, result: [] as CFArray)
         mock.expect(noErr)
         mock.expect(noErr)
+        mock.expect(errSecSuccess, result: [] as CFArray)
+        mock.expect(noErr)
+        mock.expect(noErr)
 
-        storage.defaultToken = token
+        try storage.add(token: token, with: token.id)
 
         let tokenQuery = mock.operations[3].query
         var tokenResult = tokenQuery as! [String:Any?]
@@ -156,12 +172,13 @@ final class KeychainTokenStorageTests: XCTestCase {
         defaultResult["mdat"] = Date()
         defaultResult["cdat"] = Date()
 
-        XCTAssertEqual(storage.defaultToken, token)
+        XCTAssertEqual(storage.defaultTokenID, token.id)
 
         mock.expect(noErr, result: NSArray(arrayLiteral: tokenResult as CFDictionary) as CFArray)
-        XCTAssertEqual(storage.allTokens.count, 1)
+        XCTAssertEqual(storage.allIDs.count, 1)
         
         mock.reset()
+
         mock.expect(noErr, result: tokenResult as CFDictionary)
         mock.expect(noErr)
         mock.expect(noErr, result: defaultResult as CFDictionary)
@@ -169,9 +186,9 @@ final class KeychainTokenStorageTests: XCTestCase {
         mock.expect(noErr, result: tokenResult as CFDictionary)
         mock.expect(noErr)
 
-        XCTAssertNoThrow(try storage.remove(token: token))
-        XCTAssertEqual(storage.allTokens.count, 0)
-        XCTAssertNil(storage.defaultToken)
+        XCTAssertNoThrow(try storage.remove(id: token.id))
+        XCTAssertEqual(storage.allIDs.count, 0)
+        XCTAssertNil(storage.defaultTokenID)
     }
 }
 

--- a/Tests/AuthFoundationTests/KeychainTokenStorageTests.swift
+++ b/Tests/AuthFoundationTests/KeychainTokenStorageTests.swift
@@ -20,7 +20,7 @@ final class KeychainTokenStorageTests: XCTestCase {
     let mock = MockKeychain()
     var storage: KeychainTokenStorage!
     
-    let token = Token(id: UUID(),
+    let token = Token(id: "TokenId",
                       issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,
@@ -65,7 +65,7 @@ final class KeychainTokenStorageTests: XCTestCase {
         // - Searching for tokens matching the same ID
         XCTAssertEqual(mock.operations[0].action, .copy)
         XCTAssertEqual(mock.operations[0].query["svce"] as? String, KeychainTokenStorage.serviceName)
-        XCTAssertEqual(mock.operations[0].query["acct"] as? String, token.id.uuidString)
+        XCTAssertEqual(mock.operations[0].query["acct"] as? String, token.id)
         XCTAssertEqual(mock.operations[0].query["m_Limit"] as? String, "m_LimitAll")
 
         // - Checking how many tokens are already registered
@@ -76,12 +76,12 @@ final class KeychainTokenStorageTests: XCTestCase {
 
         // - Preemptively deleting the newly-added token
         XCTAssertEqual(mock.operations[2].action, .delete)
-        XCTAssertEqual(mock.operations[2].query["acct"] as? String, token.id.uuidString)
+        XCTAssertEqual(mock.operations[2].query["acct"] as? String, token.id)
         XCTAssertEqual(mock.operations[2].query["svce"] as? String, KeychainTokenStorage.serviceName)
 
         // - Adding the new token
         XCTAssertEqual(mock.operations[3].action, .add)
-        XCTAssertEqual(mock.operations[3].query["acct"] as? String, token.id.uuidString)
+        XCTAssertEqual(mock.operations[3].query["acct"] as? String, token.id)
         XCTAssertEqual(mock.operations[3].query["svce"] as? String, KeychainTokenStorage.serviceName)
         let tokenQuery = mock.operations[3].query
         
@@ -98,7 +98,7 @@ final class KeychainTokenStorageTests: XCTestCase {
         // Adding the new default token ID
         XCTAssertEqual(mock.operations[6].action, .add)
         XCTAssertEqual(mock.operations[6].query["acct"] as? String, KeychainTokenStorage.defaultTokenName)
-        XCTAssertEqual(mock.operations[6].query["v_Data"] as? Data, token.id.uuidString.data(using: .utf8))
+        XCTAssertEqual(mock.operations[6].query["v_Data"] as? Data, token.id.data(using: .utf8))
 
         XCTAssertEqual(storage.defaultTokenID, token.id)
         

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -15,7 +15,7 @@ final class OAuth2ClientTests: XCTestCase {
     override func setUpWithError() throws {
         client = OAuth2Client(configuration, session: urlSession)
         
-        token = Token(id: UUID(),
+        token = Token(id: "TokenId",
                       issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -15,7 +15,8 @@ final class OAuth2ClientTests: XCTestCase {
     override func setUpWithError() throws {
         client = OAuth2Client(configuration, session: urlSession)
         
-        token = Token(issuedAt: Date(),
+        token = Token(id: UUID(),
+                      issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,
                       accessToken: "abcd123",

--- a/Tests/AuthFoundationTests/TokenTests.swift
+++ b/Tests/AuthFoundationTests/TokenTests.swift
@@ -48,7 +48,7 @@ final class TokenTests: XCTestCase {
     }
     
     func testToken() throws {
-        let token = Token(id: UUID(),
+        let token = Token(id: "TokenId",
                           issuedAt: Date(),
                           tokenType: "Bearer",
                           expiresIn: 3600,

--- a/Tests/AuthFoundationTests/TokenTests.swift
+++ b/Tests/AuthFoundationTests/TokenTests.swift
@@ -48,7 +48,8 @@ final class TokenTests: XCTestCase {
     }
     
     func testToken() throws {
-        let token = Token(issuedAt: Date(),
+        let token = Token(id: UUID(),
+                          issuedAt: Date(),
                           tokenType: "Bearer",
                           expiresIn: 3600,
                           accessToken: "the_access_token",

--- a/Tests/AuthFoundationTests/UserDefaultsTokenStorageTests.swift
+++ b/Tests/AuthFoundationTests/UserDefaultsTokenStorageTests.swift
@@ -18,7 +18,7 @@ final class UserDefaultTokenStorageTests: XCTestCase {
     var userDefaults: UserDefaults!
     var storage: UserDefaultsTokenStorage!
     
-    let token = Token(id: UUID(),
+    let token = Token(id: "TokenId",
                       issuedAt: Date(),
                       tokenType: "Bearer",
                       expiresIn: 300,
@@ -32,7 +32,7 @@ final class UserDefaultTokenStorageTests: XCTestCase {
                                                                   scopes: "openid"),
                                              clientSettings: nil))
 
-    let newToken = Token(id: UUID(),
+    let newToken = Token(id: "TokenId2",
                          issuedAt: Date(),
                          tokenType: "Bearer",
                          expiresIn: 300,

--- a/Tests/TestCommon/MockCredentialCoordinator.swift
+++ b/Tests/TestCommon/MockCredentialCoordinator.swift
@@ -19,6 +19,6 @@ class MockCredentialCoordinator: CredentialCoordinator {
 
     func remove(credential: Credential) throws {
         credentialDataSource.remove(credential: credential)
-        try tokenStorage.remove(token: credential.token)
+        try tokenStorage.remove(id: credential.token.id)
     }
 }

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -24,7 +24,7 @@ extension Token {
     static let simpleMockToken = mockToken()
     
     static func mockToken(issuedOffset: TimeInterval = 0, expiresIn: TimeInterval = 3600) -> Token {
-        Token(id: UUID(),
+        Token(id: "TokenId",
               issuedAt: Date(timeIntervalSinceNow: -issuedOffset),
               tokenType: "Bearer",
               expiresIn: expiresIn,

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -24,7 +24,8 @@ extension Token {
     static let simpleMockToken = mockToken()
     
     static func mockToken(issuedOffset: TimeInterval = 0, expiresIn: TimeInterval = 3600) -> Token {
-        Token(issuedAt: Date(timeIntervalSinceNow: -issuedOffset),
+        Token(id: UUID(),
+              issuedAt: Date(timeIntervalSinceNow: -issuedOffset),
               tokenType: "Bearer",
               expiresIn: expiresIn,
               accessToken: JWT.mockAccessToken,

--- a/Tests/TestCommon/MockTokenStorage.swift
+++ b/Tests/TestCommon/MockTokenStorage.swift
@@ -16,7 +16,7 @@ import AuthFoundation
 class MockTokenStorage: TokenStorage {
     var error: Error?
     
-    var defaultTokenID: UUID? {
+    var defaultTokenID: String? {
         didSet {
             if defaultTokenID != oldValue {
                 delegate?.token(storage: self, defaultChanged: defaultTokenID)
@@ -24,7 +24,7 @@ class MockTokenStorage: TokenStorage {
         }
     }
     
-    func setDefaultTokenID(_ id: UUID?) throws {
+    func setDefaultTokenID(_ id: String?) throws {
         if let error = error {
             throw error
         }
@@ -32,11 +32,11 @@ class MockTokenStorage: TokenStorage {
         defaultTokenID = id
     }
     
-    var allIDs: [UUID] { Array(allTokens.keys) }
-    private var allTokens: [UUID:Token] = [:]
-    private var metadata: [UUID:[String:String]] = [:]
+    var allIDs: [String] { Array(allTokens.keys) }
+    private var allTokens: [String:Token] = [:]
+    private var metadata: [String:[String:String]] = [:]
     
-    func add(token: Token, with id: UUID) throws {
+    func add(token: Token, with id: String) throws {
         if let error = error {
             throw error
         }
@@ -45,7 +45,7 @@ class MockTokenStorage: TokenStorage {
         delegate?.token(storage: self, added: id, token: token)
     }
     
-    func assign(metadata: [String : String], for id: UUID) throws {
+    func setMetadata(_ metadata: [String : String], for id: String) throws {
         if let error = error {
             throw error
         }
@@ -53,7 +53,7 @@ class MockTokenStorage: TokenStorage {
         self.metadata[id] = metadata
     }
     
-    func metadata(for id: UUID) throws -> [String : String] {
+    func metadata(for id: String) throws -> [String : String] {
         if let error = error {
             throw error
         }
@@ -61,7 +61,7 @@ class MockTokenStorage: TokenStorage {
         return metadata[id] ?? [:]
     }
     
-    func replace(token id: UUID, with token: Token) throws {
+    func replace(token id: String, with token: Token) throws {
         if let error = error {
             throw error
         }
@@ -69,7 +69,7 @@ class MockTokenStorage: TokenStorage {
         allTokens[id] = token
     }
     
-    func remove(id: UUID) throws {
+    func remove(id: String) throws {
         if let error = error {
             throw error
         }
@@ -78,7 +78,7 @@ class MockTokenStorage: TokenStorage {
         metadata.removeValue(forKey: id)
     }
     
-    func get(token id: UUID) throws -> Token {
+    func get(token id: String) throws -> Token {
         if let error = error {
             throw error
         }


### PR DESCRIPTION
This permits tokens to be uniquely identified by UUIDs, and to associate custom developer-assigned metadata to retrieve tokens based on their arguments.