### PR TITLE
Increase device activation wait time in UI test

### DIFF
--- a/Samples/DeviceAuthSignIn/DeviceAuthSignInUITests (iOS)/Pages/BrowserSignInScreen.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignInUITests (iOS)/Pages/BrowserSignInScreen.swift
@@ -63,7 +63,7 @@ class BrowserSignInScreen: Screen {
     }
     
     func waitForAuthorization() {
-        XCTAssertTrue(app.webViews.staticTexts["Device activated"].waitForExistence(timeout: .standard))
+        XCTAssertTrue(app.webViews.staticTexts["Device activated"].waitForExistence(timeout: .long))
         app.buttons["Done"].tap()
         XCTAssertTrue(app.webViews.firstMatch.waitForNonExistence(timeout: .short))
     }

--- a/Samples/DeviceAuthSignIn/DeviceAuthSignInUITests (iOS)/Pages/BrowserSignInScreen.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignInUITests (iOS)/Pages/BrowserSignInScreen.swift
@@ -27,6 +27,7 @@ class BrowserSignInScreen: Screen {
         
     func isVisible(timeout: TimeInterval = .long) {
         XCTAssertTrue(app.staticTexts["Activate your device"].waitForExistence(timeout: timeout))
+        testCase.save(screenshot: "Activate your device")
     }
     
     func verifyActivationCode(_ code: String) {
@@ -36,6 +37,7 @@ class BrowserSignInScreen: Screen {
         
         XCTAssertEqual(code.replacingOccurrences(of: " ", with: ""),
                        screenCode)
+        testCase.save(screenshot: "Verify activation code")
         app.webViews.buttons["Next"].tap()
     }
 
@@ -60,10 +62,13 @@ class BrowserSignInScreen: Screen {
         passwordField.typeText(password)
         
         app.webViews.buttons["Sign in"].tap()
+        testCase.save(screenshot: "Sign in")
     }
     
     func waitForAuthorization() {
-        XCTAssertTrue(app.webViews.staticTexts["Device activated"].waitForExistence(timeout: .long))
+        XCTAssertTrue(app.webViews.staticTexts["Device activated"].waitForExistence(timeout: .veryLong))
+        testCase.save(screenshot: "Device Activated")
+        
         app.buttons["Done"].tap()
         XCTAssertTrue(app.webViews.firstMatch.waitForNonExistence(timeout: .short))
     }

--- a/Samples/Shared/Common/Testing/XCTest+Extensions.swift
+++ b/Samples/Shared/Common/Testing/XCTest+Extensions.swift
@@ -17,6 +17,7 @@ extension TimeInterval {
     static let standard: TimeInterval = 3
     static let short: TimeInterval = 1
     static let long: TimeInterval = 5
+    static let veryLong: TimeInterval = 10
 }
 
 extension XCTestCase {


### PR DESCRIPTION
1 second isn't long enough to wait for device authorization grant token exchange within CI.