### PR TITLE
Remove redundant `cancel` AuthenticationFlow function

### DIFF
--- a/Sources/AuthFoundation/AuthFoundation.docc/AuthFoundation.md
+++ b/Sources/AuthFoundation/AuthFoundation.docc/AuthFoundation.md
@@ -14,11 +14,14 @@ You can use AuthFoundation when you want to:
 
 ## Topics
 
+### Essentials
+
+- ``Credential``
+
 ### User Management
 
 - <doc:ManagingUserCredentials>
 - ``Token``
-- ``Credential``
 - ``UserInfo``
 - ``TokenInfo``
 

--- a/Sources/AuthFoundation/OAuth2/Authentication.swift
+++ b/Sources/AuthFoundation/OAuth2/Authentication.swift
@@ -34,9 +34,6 @@ public protocol AuthenticationFlow: AnyObject, UsesDelegateCollection {
     /// Indicates if this flow is currently authenticating.
     var isAuthenticating: Bool { get }
     
-    /// Cancels the authentication session.
-    func cancel()
-    
     /// Resets the authentication session.
     func reset()
 }

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -288,8 +288,6 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
         }
     }
     
-    public func cancel() {}
-    
     public func reset() {
         context = nil
         isAuthenticating = false

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -252,11 +252,6 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
         timerSource.resume()
     }
     
-    /// Cancels the current authorization session.
-    public func cancel() {
-        reset()
-    }
-    
     /// Resets the flow for later reuse.
     public func reset() {
         timer?.cancel()

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -113,11 +113,6 @@ public class ResourceOwnerFlow: AuthenticationFlow {
         }
     }
     
-    /// Cancels the current authorization session.
-    public func cancel() {
-        reset()
-    }
-    
     /// Resets the flow for later reuse.
     public func reset() {
         isAuthenticating = false

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -145,12 +145,8 @@ public class TokenExchangeFlow: AuthenticationFlow {
         }
     }
 
-    /// Cancel an initiated token exchange flow.
-    public func cancel() {
-    }
-    
     public func reset() {
-        
+        isAuthenticating = false
     }
 }
 

--- a/Sources/OktaOAuth2/Logout/Logout.swift
+++ b/Sources/OktaOAuth2/Logout/Logout.swift
@@ -12,9 +12,6 @@
 
 import Foundation
 
-/// Abstract base protocol for ``LogoutFlow`` instances to use for their backing configuration.
-public protocol LogoutConfiguration {}
-
 /// A common delegate protocol that all logout flows should support.
 public protocol LogoutFlowDelegate: AnyObject {
     /// Sent when an logout flow receives an error.

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -162,8 +162,8 @@ public class WebAuthentication {
     
     /// Cancels the authentication session.
     public func cancel() {
-        signInFlow.cancel()
-        signOutFlow?.cancel()
+        signInFlow.reset()
+        signOutFlow?.reset()
         provider?.cancel()
         provider = nil
     }


### PR DESCRIPTION
The `AuthenticationFlow` protocol required both a `cancel` and `reset` function, but there wasn't any clear reason for both of those to exist. This change removes the `cancel` requirement, in favour of a more general catch-all `reset`.