### PR TITLE
Support the `slow_down` token error response in DeviceAuthorizationFlow

### DIFF
--- a/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/ViewController.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/ViewController.swift
@@ -42,9 +42,11 @@ class ViewController: UIViewController {
                                            clientId: clientId,
                                            scopes: "openid profile email offline_access")
         } else {
-            let alert = UIAlertController(title: "Client not configured", message: "Please update ViewController.swift", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
+            DispatchQueue.main.async {
+                let alert = UIAlertController(title: "Client not configured", message: "Please update ViewController.swift", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                self.present(alert, animated: true)
+            }
         }
 
         codeStackView.isHidden = true

--- a/Samples/DeviceAuthSignIn/DeviceAuthSignIn.xcodeproj/xcshareddata/xcschemes/DeviceAuthSignIn (tvOS).xcscheme
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignIn.xcodeproj/xcshareddata/xcschemes/DeviceAuthSignIn (tvOS).xcscheme
@@ -106,6 +106,33 @@
             ReferencedContainer = "container:DeviceAuthSignIn.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "E2E_USERNAME"
+            value = "$(E2E_USERNAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "E2E_PASSWORD"
+            value = "$(E2E_PASSWORD)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "E2E_DOMAIN"
+            value = "$(E2E_DOMAIN)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "E2E_CLIENT_ID"
+            value = "$(E2E_CLIENT_ID)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "E2E_SCOPES"
+            value = "$(E2E_SCOPES)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -320,11 +320,6 @@ extension DeviceAuthorizationFlow: UsesDelegateCollection {
 }
 
 extension DeviceAuthorizationFlow {
-    struct TimerInfo {
-        let context: Context
-        let completion: ((Result<Token, APIClientError>) -> Void)?
-    }
-    
     func getToken(using context: Context, completion: @escaping(Result<Token?, APIClientError>) -> Void) {
         client.openIdConfiguration { result in
             switch result {
@@ -366,10 +361,6 @@ extension DeviceAuthorizationFlow {
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
             }
         }
-    }
-    
-    func finish(_ result: Result<Token?, APIClientError>) {
-        
     }
 }
 

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -67,7 +67,7 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
     /// A model representing the context and current state for an authorization session.
     public struct Context: Decodable, Equatable, Expires {
         let deviceCode: String
-        let interval: TimeInterval
+        var interval: TimeInterval
         
         /// The date this context was created.
         public let issuedAt: Date?
@@ -226,7 +226,37 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
     ///   - context: Device authorization context object.
     ///   - completion: Optional completion block for receiving the token, or error result. If `nil`, you may rely upon the ``DeviceAuthorizationFlowDelegate/authentication(flow:received:)`` method instead.
     public func resume(with context: Context, completion: ((Result<Token, APIClientError>) -> Void)? = nil) {
+        self.completion = completion
+        scheduleTimer()
+    }
+    
+    /// Resets the flow for later reuse.
+    public func reset() {
         timer?.cancel()
+        timer = nil
+        context = nil
+        completion = nil
+        isAuthenticating = false
+    }
+
+    // MARK: Private properties / methods
+    static var slowDownInterval: TimeInterval = 5
+    
+    var timer: DispatchSourceTimer?
+    var completion: ((Result<Token, APIClientError>) -> Void)?
+    public let delegateCollection = DelegateCollection<DeviceAuthorizationFlowDelegate>()
+    
+    func scheduleTimer(offsetBy interval: TimeInterval? = nil) {
+        guard var context = context else {
+            return
+        }
+        
+        if let interval = interval {
+            context.interval += interval
+            self.context = context
+        }
+        
+        let completion = self.completion
         
         let timerSource = DispatchSource.makeTimerSource()
         timerSource.schedule(deadline: .now() + context.interval, repeating: context.interval)
@@ -241,28 +271,15 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
                     if let token = token {
                         self.reset()
                         completion?(.success(token))
-                    } else {
-                        // Return early, so we don't reset the timer
-                        return
                     }
                 }
             }
         }
+
+        timer?.cancel()
         timer = timerSource
         timerSource.resume()
     }
-    
-    /// Resets the flow for later reuse.
-    public func reset() {
-        timer?.cancel()
-        timer = nil
-        context = nil
-        isAuthenticating = false
-    }
-
-    // MARK: Private properties / methods
-    var timer: DispatchSourceTimer?
-    public let delegateCollection = DelegateCollection<DeviceAuthorizationFlowDelegate>()
 }
 
 #if swift(>=5.5.1)
@@ -319,14 +336,26 @@ extension DeviceAuthorizationFlow {
                     switch result {
                     case .failure(let error):
                         if case let APIClientError.serverError(serverError) = error,
-                           let oauthError = serverError as? OAuth2ServerError,
-                           oauthError.code == "authorization_pending"
+                           let oauthError = serverError as? OAuth2ServerError
                         {
-                            completion(.success(nil))
-                        } else {
-                            self.delegateCollection.invoke { $0.authentication(flow: self, received: .network(error: error)) }
-                            completion(.failure(error))
+                            switch oauthError.code {
+                            case "authorization_pending":
+                                // Keep polling, since we haven't received a token yet.
+                                completion(.success(nil))
+                                return
+                                
+                            case "slow_down":
+                                // Increase the polling interval for all subsequent requests, according to the specification.
+                                self.scheduleTimer(offsetBy: DeviceAuthorizationFlow.slowDownInterval)
+                                completion(.success(nil))
+                                return
+                                
+                            default: break
+                            }
                         }
+
+                        self.delegateCollection.invoke { $0.authentication(flow: self, received: .network(error: error)) }
+                        completion(.failure(error))
                     case .success(let response):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
                         completion(.success(response.result))

--- a/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowErrorTests.swift
+++ b/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowErrorTests.swift
@@ -109,6 +109,7 @@ final class DeviceAuthorizationFlowErrorTests: XCTestCase {
         XCTAssertNotNil(flow.context?.verificationUri)
         XCTAssertEqual(context, flow.context)
         XCTAssertEqual(flow.context?.verificationUri.absoluteString, "https://example.okta.com/activate")
+        XCTAssertEqual(flow.context?.interval, 1)
 
         // Exchange code
         var token: Token?

--- a/Tests/OktaOAuth2Tests/MockResponses/token-authorization_pending.json
+++ b/Tests/OktaOAuth2Tests/MockResponses/token-authorization_pending.json
@@ -1,0 +1,4 @@
+{
+   "error" : "authorization_pending",
+   "errorDescription" : "Not yet, buddy..."
+}

--- a/Tests/OktaOAuth2Tests/MockResponses/token-slow_down.json
+++ b/Tests/OktaOAuth2Tests/MockResponses/token-slow_down.json
@@ -1,0 +1,4 @@
+{
+   "error" : "slow_down",
+   "errorDescription" : "Slow up, dude..."
+}

--- a/Tests/OktaOAuth2Tests/Utilities/DeviceAuthorizationFlowDelegateRecorder.swift
+++ b/Tests/OktaOAuth2Tests/Utilities/DeviceAuthorizationFlowDelegateRecorder.swift
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+import OktaOAuth2
+
+class DeviceAuthorizationFlowDelegateRecorder: DeviceAuthorizationFlowDelegate {
+    var context: DeviceAuthorizationFlow.Context?
+    var token: Token?
+    var error: OAuth2Error?
+    var url: URL?
+    var started = false
+    var finished = false
+    
+    func authenticationStarted<Flow: DeviceAuthorizationFlow>(flow: Flow) {
+        started = true
+    }
+    
+    func authenticationFinished<Flow: DeviceAuthorizationFlow>(flow: Flow) {
+        finished = true
+    }
+
+    func authentication<Flow>(flow: Flow, received context: DeviceAuthorizationFlow.Context) {
+        self.context = context
+    }
+    
+    func authentication<Flow>(flow: Flow, received token: Token) {
+        self.token = token
+    }
+    
+    func authentication<Flow>(flow: Flow, received error: OAuth2Error) {
+        self.error = error
+    }
+
+    func authentication<Flow: DeviceAuthorizationFlow>(flow: Flow, customizeUrl urlComponents: inout URLComponents) {
+        urlComponents.fragment = "customizedUrl"
+    }
+    
+    func authentication<Flow: DeviceAuthorizationFlow>(flow: Flow, shouldAuthenticateUsing url: URL) {
+        self.url = url
+    }
+}

--- a/Tests/WebAuthenticationUITests/AuthenticationServicesProviderTests.swift
+++ b/Tests/WebAuthenticationUITests/AuthenticationServicesProviderTests.swift
@@ -77,6 +77,8 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     
     override func tearDownWithError() throws {
         provider.authenticationSession?.cancel()
+        MockAuthenticationServicesProviderSession.redirectUri = nil
+        MockAuthenticationServicesProviderSession.redirectError = nil
     }
     
     func testSuccessfulAuthentication() throws {
@@ -157,7 +159,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     }
     
     func testLogoutError() throws {
-        MockAuthenticationServicesProviderSession.redirectError = WebAuthenticationError.cannotComposeAuthenticationURL
+        MockAuthenticationServicesProviderSession.redirectError = WebAuthenticationError.userCancelledLogin
 
         provider.logout(context: .init(idToken: "idToken", state: "state"))
         try waitFor(.logoutUrl)


### PR DESCRIPTION
Corresponds to https://github.com/okta/okta-mobile-kotlin/pull/186