### PR TITLE
Use openIdConfiguration issuer when verifying ID token  issuer claim

### DIFF
--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -424,7 +424,7 @@ public final class OAuth2Client {
 
         openIdConfiguration { result in
             switch result {
-            case .success(let config):
+            case .success(let configuration):
                 // Exchange the token
                 request.send(to: self) { result in
                     guard case let .success(response) = result else {
@@ -433,7 +433,7 @@ public final class OAuth2Client {
                     }
                     
                     do {
-                        try response.result.validate(using: self, issuer: config.issuer, with: request as? IDTokenValidatorContext)
+                        try response.result.validate(using: self, issuer: configuration.issuer, with: request as? IDTokenValidatorContext)
                     } catch {
                         completion(.failure(.validation(error: error)))
                         return

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -450,11 +450,9 @@ public final class OAuth2Client {
             switch result {
             case .failure(let error):
                 completion(.failure(.serverError(error)))
-            case .success(let configuration):
+            case .success:
                 do {
-                    try response.result.validate(using: self,
-                                                 issuer: configuration.issuer,
-                                                 with: request as? IDTokenValidatorContext)
+                    try response.result.validate(using: self, with: request as? IDTokenValidatorContext)
                 } catch {
                     completion(.failure(.validation(error: error)))
                     return

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -427,22 +427,19 @@ public final class OAuth2Client {
             // Wait for the JWKS keys, if necessary
             group.notify(queue: DispatchQueue.global()) { [weak self] in
                 // Perform idToken/accessToken validation
-                self?.validateToken(
-                    request: request,
-                    keySet: keySet,
-                    oauthTokenResponse: result,
-                    completion: completion
-                )
+                self?.validateToken(request: request,
+                                    keySet: keySet,
+                                    oauthTokenResponse: result,
+                                    completion: completion)
             }
         }
     }
     
-    private func validateToken<T: OAuth2TokenRequest>(
-        request: T,
-        keySet: JWKS?,
-        oauthTokenResponse: Result<APIResponse<Token>, APIClientError>,
-        completion: @escaping (Result<APIResponse<Token>, APIClientError>) -> Void
-    ) {
+    private func validateToken<T: OAuth2TokenRequest>(request: T,
+                                                      keySet: JWKS?,
+                                                      oauthTokenResponse: Result<APIResponse<Token>, APIClientError>,
+                                                      completion: @escaping (Result<APIResponse<Token>, APIClientError>) -> Void)
+    {
         guard case let .success(response) = oauthTokenResponse else {
             completion(oauthTokenResponse)
             return
@@ -455,11 +452,9 @@ public final class OAuth2Client {
                 completion(.failure(.serverError(error)))
             case .success(let configuration):
                 do {
-                    try response.result.validate(
-                        using: self,
-                        issuer: configuration.issuer,
-                        with: request as? IDTokenValidatorContext
-                    )
+                    try response.result.validate(using: self,
+                                                 issuer: configuration.issuer,
+                                                 with: request as? IDTokenValidatorContext)
                 } catch {
                     completion(.failure(.validation(error: error)))
                     return

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -425,9 +425,9 @@ public final class OAuth2Client {
         // Exchange the token
         request.send(to: self) { result in
             // Wait for the JWKS keys, if necessary
-            group.notify(queue: DispatchQueue.global()) { [weak self] in
+            group.notify(queue: DispatchQueue.global()) {
                 // Perform idToken/accessToken validation
-                self?.validateToken(request: request,
+                self.validateToken(request: request,
                                     keySet: keySet,
                                     oauthTokenResponse: result,
                                     completion: completion)

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -425,9 +425,9 @@ public final class OAuth2Client {
         // Exchange the token
         request.send(to: self) { result in
             // Wait for the JWKS keys, if necessary
-            group.notify(queue: DispatchQueue.global()) {
+            group.notify(queue: DispatchQueue.global()) { [weak self] in
                 // Perform idToken/accessToken validation
-                self.validateToken(
+                self?.validateToken(
                     request: request,
                     keySet: keySet,
                     oauthTokenResponse: result,

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -78,13 +78,13 @@ public final class Token: Codable, Equatable, Hashable, Expires {
     
     /// Validates the claims within this JWT token, to ensure it matches the given ``OAuth2Client``.
     /// - Parameter client: Client to validate the token's claims against.
-    public func validate(using client: OAuth2Client, with context: IDTokenValidatorContext?) throws {
+    public func validate(using client: OAuth2Client, issuer: URL, with context: IDTokenValidatorContext?) throws {
         guard let idToken = idToken else {
             return
         }
 
         try Token.idTokenValidator.validate(token: idToken,
-                                            issuer: client.configuration.baseURL,
+                                            issuer: issuer,
                                             clientId: client.configuration.clientId,
                                             context: context)
         try Token.accessTokenValidator.validate(accessToken, idToken: idToken)

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -78,10 +78,13 @@ public final class Token: Codable, Equatable, Hashable, Expires {
     
     /// Validates the claims within this JWT token, to ensure it matches the given ``OAuth2Client``.
     /// - Parameter client: Client to validate the token's claims against.
-    /// - Parameter issuer: The client issuer URL.
-    public func validate(using client: OAuth2Client, issuer: URL, with context: IDTokenValidatorContext?) throws {
+    public func validate(using client: OAuth2Client, with context: IDTokenValidatorContext?) throws {
         guard let idToken = idToken else {
             return
+        }
+        
+        guard let issuer = client.openIdConfiguration?.issuer else {
+            throw JWTError.invalidIssuer
         }
 
         try Token.idTokenValidator.validate(token: idToken,

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -78,6 +78,7 @@ public final class Token: Codable, Equatable, Hashable, Expires {
     
     /// Validates the claims within this JWT token, to ensure it matches the given ``OAuth2Client``.
     /// - Parameter client: Client to validate the token's claims against.
+    /// - Parameter issuer: The client issuer URL.
     public func validate(using client: OAuth2Client, issuer: URL, with context: IDTokenValidatorContext?) throws {
         guard let idToken = idToken else {
             return

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -82,7 +82,6 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertEqual(token?.scope, "openid profile offline_access")
     }
     
-
     func testExchangeFailed() throws {
         let pkce = PKCE()
         client = OAuth2Client(
@@ -101,7 +100,7 @@ final class OAuth2ClientTests: XCTestCase {
                                                          pkce: pkce,
                                                          nonce: nil,
                                                          maxAge: nil)
-        
+
         urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
                           contentType: "application/json")
@@ -111,7 +110,7 @@ final class OAuth2ClientTests: XCTestCase {
         urlSession.expect("https://example.okta.com/oauth2/v1/token",
                           data: try data(from: .module, for: "token", in: "MockResponses"),
                           contentType: "application/json")
-    
+
         let expect = expectation(description: "network request")
         client.exchange(token: request) { result in
             guard case let .failure(error) = result,
@@ -123,7 +122,7 @@ final class OAuth2ClientTests: XCTestCase {
             XCTAssertEqual(invalidIssuer as? JWTError, JWTError.invalidIssuer)
         }
         expect.fulfill()
-        
+
         waitForExpectations(timeout: 1.0) { error in
             XCTAssertNil(error)
         }

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -85,7 +85,12 @@ final class OAuth2ClientTests: XCTestCase {
 
     func testExchangeFailed() throws {
         let pkce = PKCE()
-        client = OAuth2Client(baseURL: issuer, clientId: "theClientId", scopes: "openid profile offline_access", session: urlSession)
+        client = OAuth2Client(
+            baseURL: issuer,
+            clientId: "theClientId",
+            scopes: "openid profile offline_access",
+            session: urlSession
+        )
 
         let request = AuthorizationCodeFlow.TokenRequest(openIdConfiguration: openIdConfiguration,
                                                          clientId: "client_id",
@@ -109,7 +114,8 @@ final class OAuth2ClientTests: XCTestCase {
     
         let expect = expectation(description: "network request")
         client.exchange(token: request) { result in
-            guard case let .failure(error) = result, case let .validation(error: invalidIssuer) = error
+            guard case let .failure(error) = result,
+                  case let .validation(error: invalidIssuer) = error
             else {
                 XCTFail()
                 return

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -127,4 +127,42 @@ final class OAuth2ClientTests: XCTestCase {
             XCTAssertNil(error)
         }
     }
+    
+    func testExchangeWhenOpenIdConfigurationIsMissingResponse() throws {
+        let pkce = PKCE()
+        let request = AuthorizationCodeFlow.TokenRequest(openIdConfiguration: openIdConfiguration,
+                                                         clientId: "client_id",
+                                                         scope: "openid profile offline_access",
+                                                         redirectUri: redirectUri.absoluteString,
+                                                         grantType: .authorizationCode,
+                                                         grantValue: "abc123",
+                                                         pkce: pkce,
+                                                         nonce: nil,
+                                                         maxAge: nil)
+
+        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
+                          data: nil, statusCode: 500)
+        urlSession.expect("https://example.okta.com/oauth2/v1/keys?client_id=theClientId",
+                          data: try data(from: .module, for: "keys", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.okta.com/oauth2/v1/token",
+                          data: try data(from: .module, for: "token", in: "MockResponses"),
+                          contentType: "application/json")
+
+        let expect = expectation(description: "network request")
+        client.exchange(token: request) { result in
+            guard case let .failure(error) = result,
+                  case let .serverError(missingResponse) = error
+            else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(missingResponse.localizedDescription, APIClientError.missingResponse.localizedDescription)
+        }
+        expect.fulfill()
+
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+    }
 }

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -81,4 +81,45 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertNotNil(token?.idToken)
         XCTAssertEqual(token?.scope, "openid profile offline_access")
     }
+    
+
+    func testExchangeFailed() throws {
+        let pkce = PKCE()
+        client = OAuth2Client(baseURL: issuer, clientId: "theClientId", scopes: "openid profile offline_access", session: urlSession)
+
+        let request = AuthorizationCodeFlow.TokenRequest(openIdConfiguration: openIdConfiguration,
+                                                         clientId: "client_id",
+                                                         scope: "openid profile offline_access",
+                                                         redirectUri: redirectUri.absoluteString,
+                                                         grantType: .authorizationCode,
+                                                         grantValue: "abc123",
+                                                         pkce: pkce,
+                                                         nonce: nil,
+                                                         maxAge: nil)
+        
+        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.okta.com/oauth2/v1/keys?client_id=theClientId",
+                          data: try data(from: .module, for: "keys", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.okta.com/oauth2/v1/token",
+                          data: try data(from: .module, for: "token", in: "MockResponses"),
+                          contentType: "application/json")
+    
+        let expect = expectation(description: "network request")
+        client.exchange(token: request) { result in
+            guard case let .failure(error) = result, case let .validation(error: invalidIssuer) = error
+            else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(invalidIssuer as? JWTError, JWTError.invalidIssuer)
+        }
+        expect.fulfill()
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+    }
 }


### PR DESCRIPTION
* To support the use of vanity domains, it’s important to use the issuer URL from the opened-configuration when performing ID Token validation.