### PR TITLE
Relax the values an OpenIdConfiguration requires, and enable custom claim names

### DIFF
--- a/Sources/AuthFoundation/JWT/Claim.swift
+++ b/Sources/AuthFoundation/JWT/Claim.swift
@@ -13,150 +13,225 @@
 import Foundation
 
 /// List of registered and public claims.
-public enum Claim: String, Codable {
+public enum Claim: Codable {
     /// Issuer
-    case issuer                    = "iss"
-    case version                   = "ver"
-    case userId                    = "uid"
-    case identityProvider          = "idp"
+    case issuer
+
+    case version                   
+
+    case userId                    
+
+    case identityProvider          
+
     /// Subject
-    case subject                   = "sub"
+    case subject                   
+
     /// Audience
-    case audience                  = "aud"
+    case audience                  
+
     /// Expiration Time
-    case expirationTime            = "exp"
+    case expirationTime            
+
     /// Not Before
-    case notBefore                 = "nbf"
+    case notBefore                 
+
     /// Issued At
-    case issuedAt                  = "iat"
+    case issuedAt                  
+
     /// JWT ID
-    case jwtId                     = "jti"
+    case jwtId                     
+
     /// Full name
-    case name                      = "name"
+    case name                      
+
     /// Given name(s) or first name(s)
-    case givenName                 = "given_name"
+    case givenName                 
+
     /// Surname(s) or last name(s)
-    case familyName                = "family_name"
+    case familyName                
+
     /// Middle name(s)
-    case middleName                = "middle_name"
+    case middleName                
+
     /// Casual name
-    case nickname                  = "nickname"
+    case nickname                  
+
     /// Shorthand name by which the End-User wishes to be referred to
-    case preferredUsername         = "preferred_username"
+    case preferredUsername         
+
     /// Profile page URL
-    case profile                   = "profile"
+    case profile                   
+
     /// Profile picture URL
-    case picture                   = "picture"
+    case picture                   
+
     /// Web page or blog URL
-    case website                   = "website"
+    case website                   
+
     /// Preferred e-mail address
-    case email                     = "email"
+    case email                     
+
     /// True if the e-mail address has been verified; otherwise false
-    case emailVerified             = "email_verified"
+    case emailVerified             
+
     /// Gender
-    case gender                    = "gender"
+    case gender                    
+
     /// Birthday
-    case birthdate                 = "birthdate"
+    case birthdate                 
+
     /// Time zone
-    case zoneinfo                  = "zoneinfo"
+    case zoneinfo                  
+
     /// Locale
-    case locale                    = "locale"
+    case locale                    
+
     /// Preferred telephone number
-    case phoneNumber               = "phone_number"
+    case phoneNumber               
+
     /// True if the phone number has been verified; otherwise false
-    case phoneNumberVerified       = "phone_number_verified"
+    case phoneNumberVerified       
+
     /// Preferred postal address
-    case address                   = "address"
+    case address                   
+
     /// Time the information was last updated
-    case updatedAt                 = "updated_at"
+    case updatedAt                 
+
     /// Authorized party - the party to which the ID Token was issued
-    case authorizedParty           = "azp"
+    case authorizedParty           
+
     /// Value used to associate a Client session with an ID Token
-    case nonce                     = "nonce"
+    case nonce                     
+
     /// Time when the authentication occurred
-    case authTime                  = "auth_time"
+    case authTime                  
+
     /// Access Token hash value
-    case accessTokenHash           = "at_hash"
+    case accessTokenHash           
+
     /// Code hash value
-    case codeHash                  = "c_hash"
+    case codeHash                  
+
     /// Authentication Context Class Reference
-    case authContextClassReference = "acr"
+    case authContextClassReference 
+
     /// Authentication Methods References
-    case authMethodsReference      = "amr"
+    case authMethodsReference      
+
     /// Public key used to check the signature of an ID Token
-    case subjectPublicKey          = "sub_jwk"
+    case subjectPublicKey          
+
     /// Confirmation
-    case confirmation              = "cnf"
+    case confirmation              
+
     /// SIP From tag header field parameter value
-    case sipFromTag                = "sip_from_tag"
+    case sipFromTag                
+
     /// SIP Date header field value
-    case sipDate                   = "sip_date"
+    case sipDate                   
+
     /// SIP Call-Id header field value
-    case sipCallId                 = "sip_callid"
+    case sipCallId                 
+
     /// SIP CSeq numeric header field parameter value
-    case sipCSeqNum                = "sip_cseq_num"
+    case sipCSeqNum                
+
     /// SIP Via branch header field parameter value
-    case sipViaBranch              = "sip_via_branch"
+    case sipViaBranch              
+
     /// Originating Identity String
-    case originatingIdentity       = "orig"
+    case originatingIdentity       
+
     /// Destination Identity String
-    case destinationIdentity       = "dest"
+    case destinationIdentity       
+
     /// Media Key Fingerprint String
-    case mediaKeyFingerprint       = "mky"
+    case mediaKeyFingerprint       
+
     /// Security Events
-    case events                    = "events"
+    case events                    
+
     /// Time of Event
-    case timeOfEvent               = "toe"
+    case timeOfEvent               
+
     /// Transaction Identifier
-    case transactionId             = "txn"
+    case transactionId             
+
     /// Resource Priority Header Authorization
-    case resourcePriorityHeader    = "rph"
+    case resourcePriorityHeader    
+
     /// Session ID
-    case sessionId                 = "sid"
+    case sessionId                 
+
     /// Vector of Trust value
-    case vectorOfTrust             = "vot"
+    case vectorOfTrust             
+
     /// Vector of Trust trustmark URL
-    case vectorOfTrustMark         = "vtm"
+    case vectorOfTrustMark         
+
     /// Attestation level as defined in SHAKEN framework
-    case attestationLevel          = "attest"
+    case attestationLevel          
+
     /// Originating Identifier as defined in SHAKEN framework
-    case originatingId             = "origid"
+    case originatingId             
+
     /// Actor
-    case actor                     = "act"
+    case actor                     
+
     /// Scope Values
-    case scope                     = "scp"
+    case scope                     
+
     /// Client Identifier
-    case clientId                  = "cid"
+    case clientId                  
+
     /// "Authorized Actor - the party that is authorized to become the actor"
-    case authorizedActor           = "may_act"
+    case authorizedActor           
+
     /// jCard data
-    case jcardData                 = "jcard"
+    case jcardData                 
+
     /// Number of API requests for which the access token can be used
-    case maxAPIRequestCount        = "at_use_nbr"
+    case maxAPIRequestCount        
+
     /// Diverted Target of a Call
-    case divertedTarget            = "div"
+    case divertedTarget            
+
     /// Original PASSporT (in Full Form)
-    case originalPassport          = "opt"
+    case originalPassport          
+
     /// Verifiable Credential as specified in the W3C Recommendation
-    case verifiableCredential      = "vc"
+    case verifiableCredential      
+
     /// Verifiable Presentation as specified in the W3C Recommendation
-    case verifiablePresentation    = "vp"
+    case verifiablePresentation    
+
     /// SIP Priority header field
-    case sipPriorityHeader         = "sph"
+    case sipPriorityHeader         
+
     /// "The ACE profile a token is supposed to be used with."
-    case aceProfile                = "ace_profile"
+    case aceProfile                
+
     /// A nonce previously provided to the AS by the RS via the client.  Used to verify token freshness when the RS cannot synchronize its clock with the AS."
-    case clientNonce               = "cnonce"
+    case clientNonce               
+
     /// "Expires in.  Lifetime of the token in seconds from the time the RS first sees it.  Used to implement a weaker from of token expiration for devices that cannot synchronize their internal clocks."
-    case expiresIn                 = "exi"
+    case expiresIn                 
+
     /// Roles
-    case roles                     = "roles"
+    case roles                     
+
     /// Groups
-    case groups                    = "groups"
+    case groups                    
+
     /// Entitlements
-    case entitlements              = "entitlements"
+    case entitlements              
+
     /// Token introspection response
-    case tokenIntrospection        = "token_introspection"
+    case tokenIntrospection        
+
+    /// Custom claim with the given name
+    case custom(_ name: String)
 }
 
 /// Used by classes that contains OAuth2 claims.

--- a/Sources/AuthFoundation/JWT/Extensions/Claim+Extensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/Claim+Extensions.swift
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+extension Claim: RawRepresentable, Equatable {
+    public typealias RawValue = String
+
+    public init?(rawValue: String) {
+        switch rawValue {
+            case "iss":                    self = .issuer
+            case "ver":                    self = .version
+            case "uid":                    self = .userId
+            case "idp":                    self = .identityProvider
+            case "sub":                    self = .subject
+            case "aud":                    self = .audience
+            case "exp":                    self = .expirationTime
+            case "nbf":                    self = .notBefore
+            case "iat":                    self = .issuedAt
+            case "jti":                    self = .jwtId
+            case "name":                   self = .name
+            case "given_name":             self = .givenName
+            case "family_name":            self = .familyName
+            case "middle_name":            self = .middleName
+            case "nickname":               self = .nickname
+            case "preferred_username":     self = .preferredUsername
+            case "profile":                self = .profile
+            case "picture":                self = .picture
+            case "website":                self = .website
+            case "email":                  self = .email
+            case "email_verified":         self = .emailVerified
+            case "gender":                 self = .gender
+            case "birthdate":              self = .birthdate
+            case "zoneinfo":               self = .zoneinfo
+            case "locale":                 self = .locale
+            case "phone_number":           self = .phoneNumber
+            case "phone_number_verified":  self = .phoneNumberVerified
+            case "address":                self = .address
+            case "updated_at":             self = .updatedAt
+            case "azp":                    self = .authorizedParty
+            case "nonce":                  self = .nonce
+            case "auth_time":              self = .authTime
+            case "at_hash":                self = .accessTokenHash
+            case "c_hash":                 self = .codeHash
+            case "acr":                    self = .authContextClassReference
+            case "amr":                    self = .authMethodsReference
+            case "sub_jwk":                self = .subjectPublicKey
+            case "cnf":                    self = .confirmation
+            case "sip_from_tag":           self = .sipFromTag
+            case "sip_date":               self = .sipDate
+            case "sip_callid":             self = .sipCallId
+            case "sip_cseq_num":           self = .sipCSeqNum
+            case "sip_via_branch":         self = .sipViaBranch
+            case "orig":                   self = .originatingIdentity
+            case "dest":                   self = .destinationIdentity
+            case "mky":                    self = .mediaKeyFingerprint
+            case "events":                 self = .events
+            case "toe":                    self = .timeOfEvent
+            case "txn":                    self = .transactionId
+            case "rph":                    self = .resourcePriorityHeader
+            case "sid":                    self = .sessionId
+            case "vot":                    self = .vectorOfTrust
+            case "vtm":                    self = .vectorOfTrustMark
+            case "attest":                 self = .attestationLevel
+            case "origid":                 self = .originatingId
+            case "act":                    self = .actor
+            case "scp":                    self = .scope
+            case "cid":                    self = .clientId
+            case "may_act":                self = .authorizedActor
+            case "jcard":                  self = .jcardData
+            case "at_use_nbr":             self = .maxAPIRequestCount
+            case "div":                    self = .divertedTarget
+            case "opt":                    self = .originalPassport
+            case "vc":                     self = .verifiableCredential
+            case "vp":                     self = .verifiablePresentation
+            case "sph":                    self = .sipPriorityHeader
+            case "ace_profile":            self = .aceProfile
+            case "cnonce":                 self = .clientNonce
+            case "exi":                    self = .expiresIn
+            case "roles":                  self = .roles
+            case "groups":                 self = .groups
+            case "entitlements":           self = .entitlements
+            case "token_introspection":    self = .tokenIntrospection
+            default: self = .custom(rawValue)
+        }
+    }
+    
+    public var rawValue: String {
+        switch self {
+        case .issuer                    : return "iss"
+        case .version                   : return "ver"
+        case .userId                    : return "uid"
+        case .identityProvider          : return "idp"
+        case .subject                   : return "sub"
+        case .audience                  : return "aud"
+        case .expirationTime            : return "exp"
+        case .notBefore                 : return "nbf"
+        case .issuedAt                  : return "iat"
+        case .jwtId                     : return "jti"
+        case .name                      : return "name"
+        case .givenName                 : return "given_name"
+        case .familyName                : return "family_name"
+        case .middleName                : return "middle_name"
+        case .nickname                  : return "nickname"
+        case .preferredUsername         : return "preferred_username"
+        case .profile                   : return "profile"
+        case .picture                   : return "picture"
+        case .website                   : return "website"
+        case .email                     : return "email"
+        case .emailVerified             : return "email_verified"
+        case .gender                    : return "gender"
+        case .birthdate                 : return "birthdate"
+        case .zoneinfo                  : return "zoneinfo"
+        case .locale                    : return "locale"
+        case .phoneNumber               : return "phone_number"
+        case .phoneNumberVerified       : return "phone_number_verified"
+        case .address                   : return "address"
+        case .updatedAt                 : return "updated_at"
+        case .authorizedParty           : return "azp"
+        case .nonce                     : return "nonce"
+        case .authTime                  : return "auth_time"
+        case .accessTokenHash           : return "at_hash"
+        case .codeHash                  : return "c_hash"
+        case .authContextClassReference : return "acr"
+        case .authMethodsReference      : return "amr"
+        case .subjectPublicKey          : return "sub_jwk"
+        case .confirmation              : return "cnf"
+        case .sipFromTag                : return "sip_from_tag"
+        case .sipDate                   : return "sip_date"
+        case .sipCallId                 : return "sip_callid"
+        case .sipCSeqNum                : return "sip_cseq_num"
+        case .sipViaBranch              : return "sip_via_branch"
+        case .originatingIdentity       : return "orig"
+        case .destinationIdentity       : return "dest"
+        case .mediaKeyFingerprint       : return "mky"
+        case .events                    : return "events"
+        case .timeOfEvent               : return "toe"
+        case .transactionId             : return "txn"
+        case .resourcePriorityHeader    : return "rph"
+        case .sessionId                 : return "sid"
+        case .vectorOfTrust             : return "vot"
+        case .vectorOfTrustMark         : return "vtm"
+        case .attestationLevel          : return "attest"
+        case .originatingId             : return "origid"
+        case .actor                     : return "act"
+        case .scope                     : return "scp"
+        case .clientId                  : return "cid"
+        case .authorizedActor           : return "may_act"
+        case .jcardData                 : return "jcard"
+        case .maxAPIRequestCount        : return "at_use_nbr"
+        case .divertedTarget            : return "div"
+        case .originalPassport          : return "opt"
+        case .verifiableCredential      : return "vc"
+        case .verifiablePresentation    : return "vp"
+        case .sipPriorityHeader         : return "sph"
+        case .aceProfile                : return "ace_profile"
+        case .clientNonce               : return "cnonce"
+        case .expiresIn                 : return "exi"
+        case .roles                     : return "roles"
+        case .groups                    : return "groups"
+        case .entitlements              : return "entitlements"
+        case .tokenIntrospection        : return "token_introspection"
+        case .custom(let name)          : return name
+        }
+    }
+}

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -313,9 +313,19 @@ public final class OAuth2Client {
         openIdConfiguration { result in
             switch result {
             case .success(let configuration):
-                let request = Token.IntrospectRequest(openIdConfiguration: configuration,
-                                                      token: token,
-                                                      type: type)
+                let request: Token.IntrospectRequest
+                do {
+                    request = try Token.IntrospectRequest(openIdConfiguration: configuration,
+                                                          token: token,
+                                                          type: type)
+                } catch let error as OAuth2Error {
+                    completion(.failure(error))
+                    return
+                } catch {
+                    completion(.failure(.error(error)))
+                    return
+                }
+                
                 request.send(to: self) { result in
                     switch result {
                     case .success(let response):
@@ -338,8 +348,18 @@ public final class OAuth2Client {
         openIdConfiguration { result in
             switch result {
             case .success(let configuration):
-                let request = UserInfo.Request(openIdConfiguration: configuration,
-                                               token: token)
+                let request: UserInfo.Request
+                do {
+                    request = try UserInfo.Request(openIdConfiguration: configuration,
+                                                   token: token)
+                } catch let error as OAuth2Error {
+                    completion(.failure(error))
+                    return
+                } catch {
+                    completion(.failure(.error(error)))
+                    return
+                }
+                
                 request.send(to: self) { result in
                     switch result {
                     case .success(let response):

--- a/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
@@ -22,6 +22,7 @@ public enum OAuth2Error: Error {
     case missingClientConfiguration
     case signatureInvalid
     case missingLocationHeader
+    case missingOpenIdConfiguration(attribute: String)
     case error(_ error: Error)
 }
 
@@ -85,6 +86,14 @@ extension OAuth2Error: LocalizedError {
                                      tableName: "AuthFoundation",
                                      bundle: .authFoundation,
                                      comment: "Missing redirect Location header for token exchange")
+
+        case .missingOpenIdConfiguration(attribute: let name):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("missing_openid_configuration_attribute",
+                                  tableName: "AuthFoundation",
+                                  bundle: .authFoundation,
+                                  comment: "Invalid URL"),
+                name)
 
         case .error(let error):
             if let error = error as? LocalizedError {

--- a/Sources/AuthFoundation/Requests/Token+Requests.swift
+++ b/Sources/AuthFoundation/Requests/Token+Requests.swift
@@ -29,6 +29,21 @@ extension Token {
         let openIdConfiguration: OpenIdConfiguration
         let token: Token
         let type: Token.Kind
+        let url: URL
+        
+        init(openIdConfiguration: OpenIdConfiguration,
+             token: Token,
+             type: Token.Kind) throws
+        {
+            self.openIdConfiguration = openIdConfiguration
+            self.token = token
+            self.type = type
+            
+            guard let url = openIdConfiguration.introspectionEndpoint else {
+                throw OAuth2Error.missingOpenIdConfiguration(attribute: "introspection_endpoint")
+            }
+            self.url = url
+        }
     }
 }
 
@@ -65,7 +80,6 @@ extension Token.IntrospectRequest: OAuth2APIRequest, APIRequestBody {
     typealias ResponseType = TokenInfo
 
     var httpMethod: APIRequestMethod { .post }
-    var url: URL { openIdConfiguration.introspectionEndpoint }
     var contentType: APIContentType? { .formEncoded }
     var acceptsType: APIContentType? { .json }
     var authorization: APIAuthorization? { token }

--- a/Sources/AuthFoundation/Requests/UserInfo+Requests.swift
+++ b/Sources/AuthFoundation/Requests/UserInfo+Requests.swift
@@ -16,6 +16,19 @@ extension UserInfo {
     struct Request {
         let openIdConfiguration: OpenIdConfiguration
         let token: Token
+        let url: URL
+        
+        init(openIdConfiguration: OpenIdConfiguration,
+             token: Token) throws
+        {
+            self.openIdConfiguration = openIdConfiguration
+            self.token = token
+            
+            guard let url = openIdConfiguration.userinfoEndpoint else {
+                throw OAuth2Error.missingOpenIdConfiguration(attribute: "userinfo_endpoint")
+            }
+            self.url = url
+        }
     }
 }
 
@@ -23,7 +36,6 @@ extension UserInfo.Request: APIRequest, OAuth2APIRequest {
     typealias ResponseType = UserInfo
     
     var httpMethod: APIRequestMethod { .get }
-    var url: URL { openIdConfiguration.userinfoEndpoint }
     var acceptsType: APIContentType? { .json }
     var authorization: APIAuthorization? { token }
 }

--- a/Sources/AuthFoundation/Resources/en.lproj/AuthFoundation.strings
+++ b/Sources/AuthFoundation/Resources/en.lproj/AuthFoundation.strings
@@ -21,6 +21,7 @@
 "error_description" = "Error: %@";
 "signature_invalid_description" = "Could not verify the token's signature.";
 "missing_location_header_description" = "Missing location header for token redirect.";
+"missing_openid_configuration_attribute" = "The OpenID configuration attribute \"%@\" is missing.";
 
 /* JWTError */
 "jwt_invalid_base64_encoding" = "The token is invalid (incorrect Base64 encoding).";

--- a/Sources/AuthFoundation/Responses/GrantType.swift
+++ b/Sources/AuthFoundation/Responses/GrantType.swift
@@ -18,6 +18,7 @@ public enum GrantType: Codable, Hashable {
     case refreshToken
     case password
     case deviceCode
+    case tokenExchange
     case other(_ type: String)
 }
 
@@ -26,6 +27,7 @@ fileprivate let Mapping: [String: GrantType] = [
     "implicit": .implicit,
     "refresh_token": .refreshToken,
     "password": .password,
+    "urn:ietf:params:oauth:grant-type:token-exchange": .tokenExchange,
     "urn:ietf:params:oauth:grant-type:device_code": .deviceCode
 ]
 
@@ -52,6 +54,8 @@ extension GrantType: RawRepresentable {
             return "refresh_token"
         case .password:
             return "password"
+        case .tokenExchange:
+            return "urn:ietf:params:oauth:grant-type:token-exchange"
         case .deviceCode:
             return "urn:ietf:params:oauth:grant-type:device_code"
         }

--- a/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
+++ b/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
@@ -18,14 +18,14 @@ public struct OAuth2ServerError: Decodable, Error, LocalizedError {
     public let code: Code
     
     /// Error message, or description.
-    public let description: String
+    public let description: String?
     
     public var errorDescription: String? { description }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         code = try container.decode(Code.self, forKey: .code)
-        description = try container.decode(String.self, forKey: .description)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
     }
 
     enum CodingKeys: String, CodingKey, CaseIterable {

--- a/Sources/AuthFoundation/Responses/OpenIdConfiguration.swift
+++ b/Sources/AuthFoundation/Responses/OpenIdConfiguration.swift
@@ -17,20 +17,20 @@ import Foundation
 /// The values exposed from this configuration are typically used during authentication, or when querying a server for its capabilities.
 public struct OpenIdConfiguration: Codable, JSONDecodable {
     public let authorizationEndpoint: URL
-    public let endSessionEndpoint: URL
-    public let introspectionEndpoint: URL
+    public let endSessionEndpoint: URL?
+    public let introspectionEndpoint: URL?
     public let deviceAuthorizationEndpoint: URL?
     public let issuer: URL
     public let jwksUri: URL
-    public let registrationEndpoint: URL
+    public let registrationEndpoint: URL?
     public let revocationEndpoint: URL
     public let tokenEndpoint: URL
-    public let userinfoEndpoint: URL
+    public let userinfoEndpoint: URL?
     public let scopesSupported: [String]?
     public let responseTypesSupported: [String]
     public let responseModesSupported: [String]?
     public let claimsSupported: [Claim]
-    public let grantTypesSupported: [GrantType]
+    public let grantTypesSupported: [GrantType]?
     public let subjectTypesSupported: [String]
 
     public static let jsonDecoder: JSONDecoder = {

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
@@ -166,7 +166,11 @@ public final class SessionLogoutFlow: LogoutFlow {
                 completion?(.failure(error))
             case .success(let configuration):
                 do {
-                    let url = try self.createLogoutURL(from: configuration.endSessionEndpoint,
+                    guard let endSessionEndpoint = configuration.endSessionEndpoint else {
+                        throw OAuth2Error.missingOpenIdConfiguration(attribute: "end_session_endpoint")
+                    }
+                    
+                    let url = try self.createLogoutURL(from: endSessionEndpoint,
                                                        using: context)
                     var context = context
                     context.logoutURL = url

--- a/Sources/OktaOAuth2/Requests/TokenExchangeFlow+Requests.swift
+++ b/Sources/OktaOAuth2/Requests/TokenExchangeFlow+Requests.swift
@@ -68,7 +68,7 @@ extension TokenExchangeFlow {
         let tokens: [TokenType]
         let scope: String
         let audience: String
-        let grantType = GrantType.other("urn:ietf:params:oauth:grant-type:token-exchange")
+        let grantType = GrantType.tokenExchange
     }
 }
 

--- a/Tests/AuthFoundationTests/OpenIDConfigurationTests.swift
+++ b/Tests/AuthFoundationTests/OpenIDConfigurationTests.swift
@@ -136,15 +136,68 @@ final class OpenIDConfigurationTests: XCTestCase {
         
         XCTAssertEqual(config.issuer.absoluteString, "https://example.okta.com")
         XCTAssertEqual(config.authorizationEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/authorize")
-        XCTAssertEqual(config.endSessionEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/logout")
-        XCTAssertEqual(config.introspectionEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/introspect")
+        XCTAssertEqual(config.endSessionEndpoint?.absoluteString, "https://example.okta.com/oauth2/v1/logout")
+        XCTAssertEqual(config.introspectionEndpoint?.absoluteString, "https://example.okta.com/oauth2/v1/introspect")
         XCTAssertEqual(config.jwksUri.absoluteString, "https://example.okta.com/oauth2/v1/keys")
-        XCTAssertEqual(config.registrationEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/clients")
+        XCTAssertEqual(config.registrationEndpoint?.absoluteString, "https://example.okta.com/oauth2/v1/clients")
         XCTAssertEqual(config.revocationEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/revoke")
         XCTAssertEqual(config.tokenEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/token")
-        XCTAssertEqual(config.userinfoEndpoint.absoluteString, "https://example.okta.com/oauth2/v1/userinfo")
+        XCTAssertEqual(config.userinfoEndpoint?.absoluteString, "https://example.okta.com/oauth2/v1/userinfo")
         
         XCTAssertEqual(config.subjectTypesSupported.first, "public")
-        
+    }
+    
+    func testAppleIdConfiguration() throws {
+        let config = try decode(type: OpenIdConfiguration.self, """
+        {
+           "authorization_endpoint" : "https://appleid.apple.com/auth/authorize",
+           "claims_supported" : [
+              "aud",
+              "email",
+              "email_verified",
+              "exp",
+              "iat",
+              "is_private_email",
+              "iss",
+              "nonce",
+              "nonce_supported",
+              "real_user_status",
+              "sub",
+              "transfer_sub"
+           ],
+           "id_token_signing_alg_values_supported" : [
+              "RS256"
+           ],
+           "issuer" : "https://appleid.apple.com",
+           "jwks_uri" : "https://appleid.apple.com/auth/keys",
+           "response_modes_supported" : [
+              "query",
+              "fragment",
+              "form_post"
+           ],
+           "response_types_supported" : [
+              "code"
+           ],
+           "revocation_endpoint" : "https://appleid.apple.com/auth/revoke",
+           "scopes_supported" : [
+              "openid",
+              "email",
+              "name"
+           ],
+           "subject_types_supported" : [
+              "pairwise"
+           ],
+           "token_endpoint" : "https://appleid.apple.com/auth/token",
+           "token_endpoint_auth_methods_supported" : [
+              "client_secret_post"
+           ]
+        }
+        """)
+
+        XCTAssertNil(config.endSessionEndpoint)
+        XCTAssertNil(config.introspectionEndpoint)
+        XCTAssertNil(config.registrationEndpoint)
+        XCTAssertNil(config.userinfoEndpoint)
+        XCTAssertTrue(config.claimsSupported.contains(.custom("is_private_email")))
     }
 }


### PR DESCRIPTION
This was discovered when trying other authorization servers, such as AppleId.