### PR TITLE
Supply client_id to Introspect request call

### DIFF
--- a/Samples/UserPasswordSignIn/UserPasswordSignIn Tests/SignInTests.swift
+++ b/Samples/UserPasswordSignIn/UserPasswordSignIn Tests/SignInTests.swift
@@ -15,7 +15,7 @@ import XCTest
 class SignInTests: XCTestCase {
     var commandPath: URL?
     
-    lazy var domain: String?  = {
+    lazy var domain: String? = {
         ProcessInfo.processInfo.environment["E2E_DOMAIN"]
     }()
     

--- a/Sources/AuthFoundation/Requests/Token+Requests.swift
+++ b/Sources/AuthFoundation/Requests/Token+Requests.swift
@@ -82,10 +82,12 @@ extension Token.IntrospectRequest: OAuth2APIRequest, APIRequestBody {
     var httpMethod: APIRequestMethod { .post }
     var contentType: APIContentType? { .formEncoded }
     var acceptsType: APIContentType? { .json }
-    var authorization: APIAuthorization? { token }
+    var authorization: APIAuthorization? { nil }
+    private var clientId: String? { token.idToken?[.clientId] }
     var bodyParameters: [String: Any]? {
         [
             "token": (token.token(of: type) ?? "") as String,
+            "client_id": token.context.configuration.clientId,
             "token_type_hint": type.rawValue
         ]
     }

--- a/Sources/AuthFoundation/Requests/Token+Requests.swift
+++ b/Sources/AuthFoundation/Requests/Token+Requests.swift
@@ -83,7 +83,6 @@ extension Token.IntrospectRequest: OAuth2APIRequest, APIRequestBody {
     var contentType: APIContentType? { .formEncoded }
     var acceptsType: APIContentType? { .json }
     var authorization: APIAuthorization? { nil }
-    private var clientId: String? { token.idToken?[.clientId] }
     var bodyParameters: [String: Any]? {
         [
             "token": (token.token(of: type) ?? "") as String,

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -181,6 +181,40 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertEqual(tokenInfo?.subject, "john.doe@example.com")
     }
     
+    func testIntrospectError() throws {
+        let token = Token(id: "TokenId",
+                      issuedAt: Date(),
+                      tokenType: "Bearer",
+                      expiresIn: 300,
+                      accessToken: "abcd123",
+                      scope: "openid",
+                      refreshToken: nil,
+                      idToken: nil,
+                      deviceSecret: nil,
+                      context: Token.Context(configuration: self.configuration,
+                                             clientSettings: nil))
+        urlSession.expect("https://example.com/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/introspect", data: nil, statusCode: 401)
+        let expect = expectation(description: "network request")
+        client.introspect(token: token, type: .refreshToken) { result in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertNotNil(error)
+                XCTAssertEqual(error.localizedDescription,
+                               OAuth2Error.network(error: APIClientError.missingResponse).localizedDescription)
+            }
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
     func testRevoke() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -143,7 +143,91 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertEqual(userInfo?.subject, "00uid4BxXw6I6TV4m0g3")
     }
 
-    func testIntrospect() throws {
+    func testIntrospectTokenRequest() throws {
+        let openIdConfiguration = try OpenIdConfiguration.jsonDecoder.decode(
+            OpenIdConfiguration.self,
+            from: try data(from: .module,
+                           for: "openid-configuration",
+                           in: "MockResponses"))
+        let request = try Token.IntrospectRequest(openIdConfiguration: openIdConfiguration,
+                                                  token: token,
+                                                  type: .accessToken)
+        XCTAssertNil(request.authorization)
+        XCTAssertEqual((request.bodyParameters?["client_id"] as? String), token.context.configuration.clientId)
+        XCTAssertEqual(request.bodyParameters?["token"] as? String, token.accessToken)
+        XCTAssertEqual(request.bodyParameters?["token_type_hint"] as? String, Token.Kind.accessToken.rawValue)
+    }
+    
+    func testIntrospectActiveAccessToken() throws {
+        urlSession.expect("https://example.com/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/introspect",
+                          data: data(for: """
+                            {
+                              "active" : true,
+                              "token_type" : "Bearer",
+                              "scope" : "openid profile email",
+                              "client_id" : "a9VpZDRCeFh3Nkk2VdYa",
+                              "username" : "john.doe@example.com",
+                              "exp" : 1451606400,
+                              "sub" : "john.doe@example.com",
+                              "device_id" : "q4SZgrA9sOeHkfst5uaa"
+                            }
+                          """),
+                          contentType: "application/json")
+
+        var tokenInfo: TokenInfo?
+        let expect = expectation(description: "network request")
+        client.introspect(token: token, type: .accessToken) { result in
+            switch result {
+            case .success(let response):
+                tokenInfo = response
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertEqual(tokenInfo?.subject, "john.doe@example.com")
+        XCTAssertEqual(tokenInfo?.active, true)
+    }
+    
+    func testIntrospectInactiveAccessToken() throws {
+        urlSession.expect("https://example.com/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/introspect",
+                          data: data(for: """
+                            {
+                              "active" : false
+                            }
+                          """),
+                          contentType: "application/json")
+        var tokenInfo: TokenInfo?
+        let expect = expectation(description: "network request")
+        client.introspect(token: token, type: .accessToken) { result in
+            switch result {
+            case .success(let response):
+                tokenInfo = response
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertEqual(tokenInfo?.active, false)
+    }
+    
+    func testIntrospectActiveRefreshToken() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
                           contentType: "application/json")
@@ -179,33 +263,36 @@ final class OAuth2ClientTests: XCTestCase {
         }
         
         XCTAssertEqual(tokenInfo?.subject, "john.doe@example.com")
+        XCTAssertEqual(tokenInfo?.active, true)
     }
     
-    func testIntrospectError() throws {
-        let token = Token(id: "TokenId",
-                      issuedAt: Date(),
-                      tokenType: "Bearer",
-                      expiresIn: 300,
-                      accessToken: "abcd123",
-                      scope: "openid",
-                      refreshToken: nil,
-                      idToken: nil,
-                      deviceSecret: nil,
-                      context: Token.Context(configuration: self.configuration,
-                                             clientSettings: nil))
+    func testIntrospectActiveIdToken() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
                           contentType: "application/json")
-        urlSession.expect("https://example.com/oauth2/v1/introspect", data: nil, statusCode: 401)
+        urlSession.expect("https://example.com/oauth2/v1/introspect",
+                          data: data(for: """
+                            {
+                              "active" : true,
+                              "token_type" : "Bearer",
+                              "scope" : "openid profile email",
+                              "client_id" : "a9VpZDRCeFh3Nkk2VdYa",
+                              "username" : "john.doe@example.com",
+                              "exp" : 1451606400,
+                              "sub" : "john.doe@example.com",
+                              "device_id" : "q4SZgrA9sOeHkfst5uaa"
+                            }
+                          """),
+                          contentType: "application/json")
+
+        var tokenInfo: TokenInfo?
         let expect = expectation(description: "network request")
-        client.introspect(token: token, type: .refreshToken) { result in
+        client.introspect(token: token, type: .idToken) { result in
             switch result {
-            case .success:
-                XCTFail()
+            case .success(let response):
+                tokenInfo = response
             case .failure(let error):
-                XCTAssertNotNil(error)
-                XCTAssertEqual(error.localizedDescription,
-                               OAuth2Error.network(error: APIClientError.missingResponse).localizedDescription)
+                XCTAssertNil(error)
             }
             expect.fulfill()
         }
@@ -213,8 +300,84 @@ final class OAuth2ClientTests: XCTestCase {
         waitForExpectations(timeout: 1.0) { error in
             XCTAssertNil(error)
         }
+        
+        XCTAssertEqual(tokenInfo?.subject, "john.doe@example.com")
+        XCTAssertEqual(tokenInfo?.active, true)
     }
     
+    func testIntrospectActiveDeviceSecret() throws {
+        urlSession.expect("https://example.com/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/introspect",
+                          data: data(for: """
+                            {
+                              "active" : true,
+                              "token_type" : "Bearer",
+                              "scope" : "openid profile email",
+                              "client_id" : "a9VpZDRCeFh3Nkk2VdYa",
+                              "username" : "john.doe@example.com",
+                              "exp" : 1451606400,
+                              "sub" : "john.doe@example.com",
+                              "device_id" : "q4SZgrA9sOeHkfst5uaa"
+                            }
+                          """),
+                          contentType: "application/json")
+
+        var tokenInfo: TokenInfo?
+        let expect = expectation(description: "network request")
+        client.introspect(token: token, type: .deviceSecret) { result in
+            switch result {
+            case .success(let response):
+                tokenInfo = response
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertEqual(tokenInfo?.subject, "john.doe@example.com")
+        XCTAssertEqual(tokenInfo?.active, true)
+    }
+    
+    func testIntrospectFailed() throws {
+            let token = Token(id: "TokenId",
+                          issuedAt: Date(),
+                          tokenType: "Bearer",
+                          expiresIn: 300,
+                          accessToken: "abcd123",
+                          scope: "openid",
+                          refreshToken: nil,
+                          idToken: nil,
+                          deviceSecret: nil,
+                          context: Token.Context(configuration: self.configuration,
+                                                 clientSettings: []))
+            urlSession.expect("https://example.com/.well-known/openid-configuration",
+                              data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                              contentType: "application/json")
+            urlSession.expect("https://example.com/oauth2/v1/introspect", data: nil, statusCode: 401)
+            let expect = expectation(description: "network request")
+            client.introspect(token: token, type: .refreshToken) { result in
+                switch result {
+                case .success:
+                    XCTFail()
+                case .failure(let error):
+                    XCTAssertNotNil(error)
+                    XCTAssertEqual(error.localizedDescription,
+                                   OAuth2Error.network(error: APIClientError.missingResponse).localizedDescription)
+                }
+                expect.fulfill()
+            }
+
+            waitForExpectations(timeout: 1.0) { error in
+                XCTAssertNil(error)
+            }
+        }
+ 
     func testRevoke() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -153,9 +153,9 @@ final class OAuth2ClientTests: XCTestCase {
                                                   token: token,
                                                   type: .accessToken)
         XCTAssertNil(request.authorization)
-        XCTAssertEqual((request.bodyParameters?["client_id"] as? String), token.context.configuration.clientId)
-        XCTAssertEqual(request.bodyParameters?["token"] as? String, token.accessToken)
-        XCTAssertEqual(request.bodyParameters?["token_type_hint"] as? String, Token.Kind.accessToken.rawValue)
+        XCTAssertEqual((request.bodyParameters?["client_id"] as? String), "clientid")
+        XCTAssertEqual(request.bodyParameters?["token"] as? String, "abcd123")
+        XCTAssertEqual(request.bodyParameters?["token_type_hint"] as? String, "access_token")
     }
     
     func testIntrospectActiveAccessToken() throws {


### PR DESCRIPTION
- Include the client_id as a query parameter when calling the /introspect endpoint. 
- do not pass the Authorization header in the request
- Link to swagger doc:  https://developer.okta.com/docs/reference/api/oidc/#introspect