### PR TITLE
Improve Cocoapods compatibility on Xcode 14

### DIFF
--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaAuthFoundation"
     s.module_name      = "AuthFoundation"
-    s.version          = "1.1.0"
+    s.version          = "1.1.1"
     s.summary          = "Okta Authentication Foundation"
     s.description      = <<-DESC
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.1.0"
+    s.version          = "1.1.1"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.1.0"
+    s.version          = "1.1.1"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.1.0   | ✔️ Stable                             |
+| 1.1.1   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/AuthFoundation/Security/Keychain.swift
+++ b/Sources/AuthFoundation/Security/Keychain.swift
@@ -14,7 +14,7 @@ import Foundation
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
-#if canImport(LocalAuthentication)
+#if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 extension LAContext: KeychainAuthenticationContext {}
 #endif

--- a/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
@@ -101,7 +101,7 @@ final class KeychainTokenStorage: TokenStorage {
                                          value: try encoder.encode(metadata))
 
         var context: KeychainAuthenticationContext? = nil
-        #if canImport(LocalAuthentication)
+        #if canImport(LocalAuthentication) && !os(tvOS)
         context = security.context
         #endif
 
@@ -144,7 +144,7 @@ final class KeychainTokenStorage: TokenStorage {
                                     value: data)
         
         var context: KeychainAuthenticationContext? = nil
-        #if canImport(LocalAuthentication)
+        #if canImport(LocalAuthentication) && !os(tvOS)
         context = security?.context
         #endif
 

--- a/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if canImport(LocalAuthentication)
+#if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 #else
 typealias LAContext = Void

--- a/Sources/AuthFoundation/Token Management/TokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/TokenStorage.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if canImport(LocalAuthentication)
+#if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 
 extension LAContext: TokenAuthenticationContext {}

--- a/Sources/AuthFoundation/User Management/CredentialSecurity.swift
+++ b/Sources/AuthFoundation/User Management/CredentialSecurity.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if canImport(LocalAuthentication)
+#if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 #endif
 
@@ -37,7 +37,7 @@ extension Credential {
         /// Assigns a custom access group for this credential.
         case accessGroup(_ name: String)
 
-        #if canImport(LocalAuthentication)
+        #if canImport(LocalAuthentication) && !os(tvOS)
         /// Defines a custom LocalAuthentication context for interactions with this credential, for systems that support it.
         case context(_ obj: LAContext)
         #endif

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -103,7 +103,7 @@ final class CredentialCoordinatorImpl: CredentialCoordinator {
     {
         if let defaultTokenId = tokenStorage.defaultTokenID {
             var context: TokenAuthenticationContext?
-            #if canImport(LocalAuthentication)
+            #if canImport(LocalAuthentication) && !os(tvOS)
             context = Credential.Security.standard.context
             #endif
             

--- a/Sources/AuthFoundation/User Management/Internal/CredentialSecurity+Internal.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialSecurity+Internal.swift
@@ -18,7 +18,7 @@ import LocalAuthentication
 
 extension Array where Element == Credential.Security {
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    #if canImport(LocalAuthentication)
+    #if canImport(LocalAuthentication) && !os(tvOS)
     var context: LAContext? {
         for case let Credential.Security.context(value) in self {
             return value

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -12,4 +12,4 @@
 
 import Foundation
 
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.1.0")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.1.1")

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -12,4 +12,4 @@
 
 @_exported import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.1.0")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.1.1")

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -13,4 +13,4 @@
 import Foundation
 import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.1.0")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.1.1")

--- a/Tests/AuthFoundationTests/CredentialSecurityTests.swift
+++ b/Tests/AuthFoundationTests/CredentialSecurityTests.swift
@@ -15,7 +15,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if canImport(LocalAuthentication)
+#if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 
 final class CredentialSecurityTests: XCTestCase {


### PR DESCRIPTION
Within Xcode 14, `canImport(LocalAuthentication)` will succeed on tvOS, even though `LAContext` is not available, so additional precompiler checks are required.