### PR TITLE
Ensure refresh token is present before trying to refresh.

### DIFF
--- a/Sources/AuthFoundation/Network/APIClientError.swift
+++ b/Sources/AuthFoundation/Network/APIClientError.swift
@@ -121,3 +121,39 @@ extension APIClientError: LocalizedError {
         }
     }
 }
+
+extension APIClientError: Equatable {
+    private static func compare(lhs: NSError, rhs: NSError) -> Bool {
+        (lhs.code == rhs.code &&
+         lhs.domain == rhs.domain)
+    }
+    
+    public static func == (lhs: APIClientError, rhs: APIClientError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidUrl, .invalidUrl): return true
+        case (.missingResponse, .missingResponse): return true
+        case (.invalidResponse, .invalidResponse): return true
+        case (.invalidRequestData, .invalidRequestData): return true
+        case (.missingRefreshSettings, .missingRefreshSettings): return true
+        case (.unknown, .unknown): return true
+            
+        case (.unsupportedContentType(let lhsType), .unsupportedContentType(let rhsType)):
+            return lhsType == rhsType
+            
+        case (.statusCode(let lhsStatusCode), .statusCode(let rhsStatusCode)):
+            return lhsStatusCode == rhsStatusCode
+            
+        case (.cannotParseResponse(error: let lhsError), .cannotParseResponse(error: let rhsError)):
+            return compare(lhs: lhsError as NSError, rhs: rhsError as NSError)
+            
+        case (.serverError(let lhsError), .serverError(let rhsError)):
+            return compare(lhs: lhsError as NSError, rhs: rhsError as NSError)
+
+        case (.validation(error: let lhsError), .validation(error: let rhsError)):
+            return compare(lhs: lhsError as NSError, rhs: rhsError as NSError)
+            
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/AuthFoundation/Network/OktaAPIError.swift
+++ b/Sources/AuthFoundation/Network/OktaAPIError.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Describes errors that may be reported from an Okta API endpoint.
-public struct OktaAPIError: Decodable, Error, LocalizedError {
+public struct OktaAPIError: Decodable, Error, LocalizedError, Equatable {
     /// An Okta code for this type of error.
     public let code: String
     

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -200,8 +200,11 @@ public final class OAuth2Client {
     ///   - token: Token to refresh.
     ///   - completion: Completion bock invoked with the result.
     public func refresh(_ token: Token, completion: @escaping (Result<Token, OAuth2Error>) -> Void) {
-        guard let clientSettings = token.context.clientSettings else {
-            completion(.failure(.missingToken(type: .refreshToken)))
+        let type = Token.Kind.refreshToken
+        guard let clientSettings = token.context.clientSettings,
+              clientSettings[type.rawValue] != nil
+        else {
+            completion(.failure(.missingToken(type: type)))
             return
         }
         

--- a/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
@@ -130,3 +130,44 @@ extension OAuth2Error: LocalizedError {
         }
     }
 }
+
+extension OAuth2Error: Equatable {
+    private static func compare(lhs: NSError, rhs: NSError) -> Bool {
+        (lhs.code == rhs.code &&
+         lhs.domain == rhs.domain)
+    }
+    
+    public static func == (lhs: OAuth2Error, rhs: OAuth2Error) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidUrl, .invalidUrl): return true
+        case (.cannotComposeUrl, .cannotComposeUrl): return true
+        case (.signatureInvalid, .signatureInvalid): return true
+        case (.missingLocationHeader, .missingLocationHeader): return true
+        case (.missingClientConfiguration, .missingClientConfiguration): return true
+
+        case (.oauth2Error(code: let lhsCode, description: let lhsDescription), .oauth2Error(code: let rhsCode, description: let rhsDescription)):
+            return (lhsCode == rhsCode && lhsDescription == rhsDescription)
+            
+        case (.network(error: let lhsError), .network(error: let rhsError)):
+            return lhsError == rhsError
+            
+        case (.missingToken(type: let lhsKind), .missingToken(type: let rhsKind)):
+            return lhsKind == rhsKind
+            
+        case (.missingOpenIdConfiguration(attribute: let lhsAttribute), .missingOpenIdConfiguration(attribute: let rhsAttribute)):
+            return lhsAttribute == rhsAttribute
+            
+        case (.error(let lhsError), .error(let rhsError)):
+            return compare(lhs: lhsError as NSError, rhs: rhsError as NSError)
+
+        case (.cannotRevoke(type: let lhsType), .cannotRevoke(type: let rhsType)):
+            return lhsType == rhsType
+            
+        case (.multiple(errors: let lhsErrors), .multiple(errors: let rhsErrors)):
+            return lhsErrors == rhsErrors
+            
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
+++ b/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Describes errors reported from an OAuth2 server.
-public struct OAuth2ServerError: Decodable, Error, LocalizedError {
+public struct OAuth2ServerError: Decodable, Error, LocalizedError, Equatable {
     /// Error code.
     public let code: Code
     

--- a/Tests/AuthFoundationTests/CredentialRefreshTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRefreshTests.swift
@@ -158,6 +158,27 @@ final class CredentialRefreshTests: XCTestCase, OAuth2ClientDelegate {
         XCTAssertNotNil(credentialNotification.userInfo?["error"])
     }
     
+    func testRefreshWithoutRefreshToken() throws {
+        let credential = try credential(for: Token.mockToken(id: "TokenID",
+                                                             refreshToken: nil))
+
+        let expect = expectation(description: "refresh")
+        credential.refresh { result in
+            switch result {
+            case .success(_):
+                XCTFail("Did not expect a success response")
+            case .failure(let error):
+                XCTAssertNotNil(error)
+                XCTAssertEqual(error, .missingToken(type: .refreshToken))
+            }
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 3.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+
     func testRefreshWithoutOptionalValues() throws {
         let credential = try credential(for: Token.mockToken(id: "TokenID",
                                                              deviceSecret: "theDeviceSecret"))

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -22,11 +22,11 @@ final class OAuth2ClientTests: XCTestCase {
                       expiresIn: 300,
                       accessToken: "abcd123",
                       scope: "openid",
-                      refreshToken: nil,
+                      refreshToken: "refresh",
                       idToken: nil,
                       deviceSecret: nil,
                       context: Token.Context(configuration: self.configuration,
-                                             clientSettings: [ "client_id": "clientid" ]))
+                                             clientSettings: [ "client_id": "clientid", "refresh_token": "refresh" ]))
         
         urlSession.requestDelay = 0.1
     }

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -14,22 +14,25 @@ import Foundation
 @testable import AuthFoundation
 
 extension Token {
-    static let mockContext = Token.Context(
-        configuration: OAuth2Client.Configuration(
-            baseURL: URL(string: "https://example.com")!,
-            clientId: "0oa3en4fIMQ3ddc204w5",
-            scopes: "offline_access profile openid"),
-        clientSettings: [ "client_id": "0oa3en4fIMQ3ddc204w5" ])
+    static let mockConfiguration = OAuth2Client.Configuration(
+        baseURL: URL(string: "https://example.com")!,
+        clientId: "0oa3en4fIMQ3ddc204w5",
+        scopes: "offline_access profile openid")
 
     static let simpleMockToken = mockToken()
     
     static func mockToken(id: String = "TokenId",
-                          refreshToken: String? = nil,
+                          refreshToken: String? = "abc123",
                           deviceSecret: String? = nil,
                           issuedOffset: TimeInterval = 0,
                           expiresIn: TimeInterval = 3600) -> Token
     {
-        Token(id: id,
+        var clientSettings = [ "client_id": mockConfiguration.clientId ]
+        if let refreshToken = refreshToken {
+            clientSettings["refresh_token"] = refreshToken
+        }
+        
+        return Token(id: id,
               issuedAt: Date(timeIntervalSinceNow: -issuedOffset),
               tokenType: "Bearer",
               expiresIn: expiresIn,
@@ -38,6 +41,7 @@ extension Token {
               refreshToken: refreshToken,
               idToken: try? JWT(JWT.mockIDToken),
               deviceSecret: deviceSecret,
-              context: mockContext)
+              context: .init(configuration: mockConfiguration,
+                             clientSettings: clientSettings))
     }
 }

--- a/Tests/WebAuthenticationUITests/WebAuthTests.swift
+++ b/Tests/WebAuthenticationUITests/WebAuthTests.swift
@@ -42,8 +42,6 @@ class WebAuthenticationUITests: XCTestCase {
     }
     
     func testStart() throws {
-        XCTAssertNotNil(WebAuthentication.shared)
-        
         let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow, context: .init(state: "qwe"))
         
         webAuth.signIn(from: nil) { result in }


### PR DESCRIPTION
Additionally, ensure some error types are equatable, to make testing simpler.