### PR TITLE
Stop using the refresh token from the clientSettings, since it's no longer stored there

### DIFF
--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -200,11 +200,10 @@ public final class OAuth2Client {
     ///   - token: Token to refresh.
     ///   - completion: Completion bock invoked with the result.
     public func refresh(_ token: Token, completion: @escaping (Result<Token, OAuth2Error>) -> Void) {
-        let type = Token.Kind.refreshToken
         guard let clientSettings = token.context.clientSettings,
-              clientSettings[type.rawValue] != nil
+              token.refreshToken != nil
         else {
-            completion(.failure(.missingToken(type: type)))
+            completion(.failure(.missingToken(type: .refreshToken)))
             return
         }
         

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -27,10 +27,7 @@ extension Token {
                           issuedOffset: TimeInterval = 0,
                           expiresIn: TimeInterval = 3600) -> Token
     {
-        var clientSettings = [ "client_id": mockConfiguration.clientId ]
-        if let refreshToken = refreshToken {
-            clientSettings["refresh_token"] = refreshToken
-        }
+        let clientSettings = [ "client_id": mockConfiguration.clientId ]
         
         return Token(id: id,
               issuedAt: Date(timeIntervalSinceNow: -issuedOffset),


### PR DESCRIPTION
In the previous PR #102 the refresh handling added verification checks to ensure the refresh token was present before triggering a refresh, so the appropriate error message can be returned. However, this was pulling the refresh token from a property of `clientSettings` which no longer was present in new builds of the SDK.

This update changes this behaviour to use the refresh token directly from the Token object instead.