### PR TITLE
Fix a race condition that sometimes prevents tokens from being stored after a refresh

### DIFF
--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaAuthFoundation"
     s.module_name      = "AuthFoundation"
-    s.version          = "1.1.4"
+    s.version          = "1.1.5"
     s.summary          = "Okta Authentication Foundation"
     s.description      = <<-DESC
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.1.4"
+    s.version          = "1.1.5"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.1.4"
+    s.version          = "1.1.5"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.1.4   | ✔️ Stable                             |
+| 1.1.5   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
@@ -47,12 +47,18 @@ class ProfileTableViewController: UITableViewController {
         didSet {
             configure(credential?.userInfo)
             credential?.automaticRefresh = true
-            credential?.refreshIfNeeded { _ in
-                self.credential?.userInfo { result in
-                    guard case let .success(userInfo) = result else { return }
-                    DispatchQueue.main.async {
-                        self.configure(userInfo)
+            credential?.refreshIfNeeded { result in
+                switch result {
+                case .success():
+                    self.credential?.userInfo { result in
+                        guard case let .success(userInfo) = result else { return }
+                        DispatchQueue.main.async {
+                            self.configure(userInfo)
+                        }
                     }
+                    
+                case .failure(let error):
+                    self.show(error: error)
                 }
             }
         }

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -319,7 +319,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     
     // MARK: OAuth2ClientDelegate
     public func oauth(client: OAuth2Client, didRefresh token: Token, replacedWith newToken: Token?) {
-        guard token == self.token,
+        guard token.id == self.token.id,
               let newToken = newToken
         else {
             return
@@ -329,8 +329,8 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     }
     
     // MARK: Private properties
-    fileprivate static let coordinator = CredentialCoordinatorImpl()
-    internal weak var coordinator: CredentialCoordinator?
+    static let coordinator = CredentialCoordinatorImpl()
+    weak var coordinator: CredentialCoordinator?
 
     private lazy var _metadata: Token.Metadata = {
         if let metadata = try? coordinator?.tokenStorage.metadata(for: token.id) {

--- a/Sources/AuthFoundation/User Management/CredentialCoordinator.swift
+++ b/Sources/AuthFoundation/User Management/CredentialCoordinator.swift
@@ -17,5 +17,6 @@ public protocol CredentialCoordinator: AnyObject {
     var credentialDataSource: CredentialDataSource { get set }
     var tokenStorage: TokenStorage { get set }
     
+    func observe(oauth2 client: OAuth2Client)
     func remove(credential: Credential) throws
 }

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -12,4 +12,4 @@
 
 import Foundation
 
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.1.4")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.1.5")

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -12,4 +12,4 @@
 
 @_exported import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.1.4")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.1.5")

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -13,4 +13,4 @@
 import Foundation
 import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.1.4")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.1.5")

--- a/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
+++ b/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
@@ -82,11 +82,14 @@ final class UserCoordinatorTests: XCTestCase {
     }
     
     func testNotifications() throws {
+        let oldCredential = coordinator.default
+        
         let recorder = NotificationRecorder(observing: [.defaultCredentialChanged])
         
         let credential = try coordinator.store(token: token, tags: [:], security: [])
         XCTAssertEqual(recorder.notifications.count, 1)
         XCTAssertEqual(recorder.notifications.first?.object as? Credential, credential)
+        XCTAssertNotEqual(oldCredential, credential)
         
         recorder.reset()
         coordinator.default = nil

--- a/Tests/TestCommon/MockCredentialCoordinator.swift
+++ b/Tests/TestCommon/MockCredentialCoordinator.swift
@@ -21,4 +21,7 @@ class MockCredentialCoordinator: CredentialCoordinator {
         credentialDataSource.remove(credential: credential)
         try tokenStorage.remove(id: credential.token.id)
     }
+    
+    func observe(oauth2 client: OAuth2Client) {
+    }
 }


### PR DESCRIPTION
This fixes https://github.com/okta/okta-idx-swift/issues/120

Ultimately the root cause was due to the CredentialCoordinatorImpl relying on NSNotifications to detect the creation of a new OAuth2Client so it could be added as a delegate. However, if the client is created _before_ the CredentialCoordinatorImpl, then it won't be able to receive delegate calls to [oauth(client:didRefresh:replacedWith:)](https://okta.github.io/okta-mobile-swift/development/authfoundation/documentation/authfoundation/oauth2clientdelegate/oauth(client:didrefresh:replacedwith:)-2rj5a), which is used to trigger a token storage.

This fix works around the issue by having the OAuth2Client explicitly add itself to the CredentialCoordinator, causing it to be initialized on-demand.