### PR TITLE
Support customizing HTTP status code handling

### DIFF
--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaAuthFoundation"
     s.module_name      = "AuthFoundation"
-    s.version          = "1.1.5"
+    s.version          = "1.2.0"
     s.summary          = "Okta Authentication Foundation"
     s.description      = <<-DESC
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.1.5"
+    s.version          = "1.2.0"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.1.5"
+    s.version          = "1.2.0"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.1.5   | ✔️ Stable                             |
+| 1.2.0   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/AuthFoundation/Network/APIClient.swift
+++ b/Sources/AuthFoundation/Network/APIClient.swift
@@ -93,7 +93,9 @@ extension APIClientDelegate {
 
 /// List of retry options
 public enum APIRetry {
+    /// Indicates the APIRequest should not be retried.
     case doNotRetry
+    /// The APIRequest should be retried, up to the given maximum number of times.
     case retry(maximumCount: Int)
     
     /// The default retry option.
@@ -114,9 +116,13 @@ public enum APIRetry {
     }
 }
 
+/// Defines the possible results for an API request.
 public enum APIResponseResult {
+    /// Indicates the request was successful.
     case success
+    /// The server is indicating the request should be retried.
     case retry
+    /// The server reports the response represents an error.
     case error
 
     init(statusCode: Int) {
@@ -298,6 +304,7 @@ extension APIClient {
                                               from: jsonData,
                                               userInfo: context?.codingUserInfo),
                            date: date ?? Date(),
+                           statusCode: response.statusCode,
                            links: relatedLinks(from: response.allHeaderFields["Link"] as? String),
                            rateInfo: rateInfo,
                            requestId: requestId)

--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -136,6 +136,11 @@ public protocol APIParsingContext {
     /// Optional coding user info to use when parsing ``APIRequest`` responses.
     var codingUserInfo: [CodingUserInfoKey: Any]? { get }
     
+    /// Enables the response from an ``APIRequest`` to be customized.
+    ///
+    /// The default implementation utilizes the response's status code to report the appropriate result.
+    /// - Parameter response: The response returned from the server.
+    /// - Returns: The result that should be inferred from this response.
     func resultType(from response: HTTPURLResponse) -> APIResponseResult
     
     /// Generates an error response from an ``APIRequest`` result when an HTTP error occurs.

--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -136,6 +136,8 @@ public protocol APIParsingContext {
     /// Optional coding user info to use when parsing ``APIRequest`` responses.
     var codingUserInfo: [CodingUserInfoKey: Any]? { get }
     
+    func resultType(from response: HTTPURLResponse) -> APIResponseResult
+    
     /// Generates an error response from an ``APIRequest`` result when an HTTP error occurs.
     /// - Parameter data: Raw data returned from the HTTP response.
     /// - Returns: Optional error option described within the supplied data.
@@ -144,6 +146,9 @@ public protocol APIParsingContext {
 
 extension APIParsingContext {
     public func error(from data: Data) -> Error? { nil }
+    public func resultType(from response: HTTPURLResponse) -> APIResponseResult {
+        APIResponseResult(statusCode: response.statusCode)
+    }
 }
 
 extension APIRequest where Self: APIRequestBody {

--- a/Sources/AuthFoundation/Network/APIResponse.swift
+++ b/Sources/AuthFoundation/Network/APIResponse.swift
@@ -28,6 +28,9 @@ public struct APIResponse<T: Decodable>: Decodable {
     /// The date the response was received, as reported by the server.
     public let date: Date
     
+    /// The actual HTTP status code for the result.
+    public let statusCode: Int
+    
     /// Information about links between related resources.
     public let links: [Link: URL]
     

--- a/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
+++ b/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
@@ -63,5 +63,7 @@ extension OAuth2ServerError {
         case unsupportedResponseType = "unsupported_response_type"
         /// The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes.
         case unsupportedResponseMode = "unsupported_response_mode"
+        /// The client specified is not authorized to utilize the supplied grant type.
+        case unauthorizedClient = "unauthorized_client"
     }
 }

--- a/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
+++ b/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
@@ -35,35 +35,111 @@ public struct OAuth2ServerError: Decodable, Error, LocalizedError, Equatable {
 }
 
 extension OAuth2ServerError {
-    ///  Possible  OAuth 2.0 server error code
-    public enum Code: String, Decodable {
+    /// Possible  OAuth 2.0 server error code
+    public enum Code: Decodable {
         /// The authorization request is still pending as the end user hasn't yet completed the user-interaction step
-        case authorizationPending = "authorization_pending"
+        case authorizationPending
         /// the authorization request is still pending and polling should continue
-        case slowDown = "slow_down"
+        case slowDown
         //The "device_code" has expired, and the device authorization session has concluded.
-        case expiredToken = "expired_token"
+        case expiredToken
         /// The server denied the request.
-        case accessDenied = "access_denied"
+        case accessDenied
         /// The specified client ID is invalid.
-        case invalidClient = "invalid_client"
+        case invalidClient
         /// The specified grant is invalid, expired, revoked, or doesn't match the redirect URI used in the authorization request.
-        case invalidGrant = "invalid_grant"
+        case invalidGrant
         /// The request is missing a necessary parameter, the parameter has an invalid value, or the request contains duplicate parameters.
-        case invalidRequest = "invalid_request"
+        case invalidRequest
         /// The scopes list contains an invalid or unsupported value.
-        case invalidScope = "invalid_scope"
+        case invalidScope
         /// The provided access token is invalid.
-        case invalidToken = "invalid_token"
+        case invalidToken
         /// The server encountered an internal error.
-        case serverError = "server_error"
+        case serverError
         /// The server is temporarily unavailable, but should be able to process the request at a later time.
-        case temporarilyUnavailable = "temporarily_unavailable"
+        case temporarilyUnavailable
         /// The specified response type is invalid or unsupported.
-        case unsupportedResponseType = "unsupported_response_type"
+        case unsupportedResponseType
         /// The specified response mode is invalid or unsupported. This error is also thrown for disallowed response modes.
-        case unsupportedResponseMode = "unsupported_response_mode"
+        case unsupportedResponseMode
         /// The client specified is not authorized to utilize the supplied grant type.
-        case unauthorizedClient = "unauthorized_client"
+        case unauthorizedClient
+        /// An error code other than one of the standard ones defined above.
+        case other(code: String)
+    }
+}
+
+extension OAuth2ServerError.Code: RawRepresentable, Equatable {
+    public typealias RawValue = String
+    
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "authorization_pending":
+            self = .authorizationPending
+        case "slow_down":
+            self = .slowDown
+        case "expired_token":
+            self = .expiredToken
+        case "access_denied":
+            self = .accessDenied
+        case "invalid_client":
+            self = .invalidClient
+        case "invalid_grant":
+            self = .invalidGrant
+        case "invalid_request":
+            self = .invalidRequest
+        case "invalid_scope":
+            self = .invalidScope
+        case "invalid_token":
+            self = .invalidToken
+        case "server_error":
+            self = .serverError
+        case "temporarily_unavailable":
+            self = .temporarilyUnavailable
+        case "unsupported_response_type":
+            self = .unsupportedResponseType
+        case "unsupported_response_mode":
+            self = .unsupportedResponseMode
+        case "unauthorized_client":
+            self = .unauthorizedClient
+        default:
+            self = .other(code: rawValue)
+        }
+    }
+    
+    public var rawValue: String {
+        switch self {
+        case .authorizationPending:
+            return "authorization_pending"
+        case .slowDown:
+            return "slow_down"
+        case .expiredToken:
+            return "expired_token"
+        case .accessDenied:
+            return "access_denied"
+        case .invalidClient:
+            return "invalid_client"
+        case .invalidGrant:
+            return "invalid_grant"
+        case .invalidRequest:
+            return "invalid_request"
+        case .invalidScope:
+            return "invalid_scope"
+        case .invalidToken:
+            return "invalid_token"
+        case .serverError:
+            return "server_error"
+        case .temporarilyUnavailable:
+            return "temporarily_unavailable"
+        case .unsupportedResponseType:
+            return "unsupported_response_type"
+        case .unsupportedResponseMode:
+            return "unsupported_response_mode"
+        case .unauthorizedClient:
+            return "unauthorized_client"
+        case .other(code: let code):
+            return code
+        }
     }
 }

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -12,4 +12,4 @@
 
 import Foundation
 
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.1.5")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.2.0")

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -12,4 +12,4 @@
 
 @_exported import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.1.5")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.2.0")

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -13,4 +13,4 @@
 import Foundation
 import AuthFoundation
 
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.1.5")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.2.0")

--- a/Tests/AuthFoundationTests/APIClientTests.swift
+++ b/Tests/AuthFoundationTests/APIClientTests.swift
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import AuthFoundation
+@testable import TestCommon
+
+struct MockApiParsingContext: APIParsingContext {
+    var codingUserInfo: [CodingUserInfoKey : Any]?
+    
+    let result: APIResponseResult?
+    
+    func resultType(from response: HTTPURLResponse) -> APIResponseResult {
+        result ?? APIResponseResult(statusCode: response.statusCode)
+    }
+}
+
+class APIClientTests: XCTestCase {
+    var client: MockApiClient!
+    let baseUrl = URL(string: "https://example.okta.com/oauth2/v1/token")!
+    var configuration: OAuth2Client.Configuration!
+    let urlSession = URLSessionMock()
+    let requestId = UUID().uuidString
+    
+    override func setUpWithError() throws {
+        configuration = OAuth2Client.Configuration(baseURL: baseUrl,
+                                                   clientId: "clientid",
+                                                   scopes: "openid")
+        client = MockApiClient(configuration: configuration,
+                               session: urlSession,
+                               baseURL: baseUrl)
+    }
+
+    func testOverrideRequestResult() throws {
+        client = MockApiClient(configuration: configuration,
+                               session: urlSession,
+                               baseURL: baseUrl,
+                               shouldRetry: .doNotRetry)
+
+        urlSession.expect("https://example.okta.com/oauth2/v1/token",
+                          data: try data(from: .module, for: "token", in: "MockResponses"),
+                          statusCode: 400,
+                          contentType: "application/json",
+                          headerFields: ["x-rate-limit-limit": "0",
+                                         "x-rate-limit-remaining": "0",
+                                         "x-rate-limit-reset": "1609459200",
+                                         "Date": "Fri, 09 Sep 2022 02:22:14 GMT",
+                                         "x-okta-request-id": requestId])
+        
+        let apiRequest = MockApiRequest(url: baseUrl)
+        let context = MockApiParsingContext(result: .success)
+
+        let expect = expectation(description: "network request")
+        apiRequest.send(to: client, parsing: context, completion: { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.statusCode, 400)
+            case .failure(_):
+                XCTFail("Did not expect the request to fail")
+            }
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: 9.0) { error in
+            XCTAssertNil(error)
+        }
+    }
+}

--- a/Tests/AuthFoundationTests/ErrorTests.swift
+++ b/Tests/AuthFoundationTests/ErrorTests.swift
@@ -190,4 +190,11 @@ final class ErrorTests: XCTestCase {
         XCTAssertEqual(error.description, "Description")
         XCTAssertEqual(error.errorDescription, "Description")
     }
+    
+    func testOAuth2ServerErrorCodes() {
+        typealias Code = OAuth2ServerError.Code
+        XCTAssertEqual(Code(rawValue: "access_denied"), .accessDenied)
+        XCTAssertEqual(Code.accessDenied.rawValue, "access_denied")
+        XCTAssertEqual(Code.accessDenied, Code.other(code: "access_denied"))
+    }
 }

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -345,7 +345,7 @@ final class OAuth2ClientTests: XCTestCase {
     }
     
     func testIntrospectFailed() throws {
-            let token = Token(id: "TokenId",
+        let token = Token(id: "TokenId",
                           issuedAt: Date(),
                           tokenType: "Bearer",
                           expiresIn: 300,
@@ -356,27 +356,27 @@ final class OAuth2ClientTests: XCTestCase {
                           deviceSecret: nil,
                           context: Token.Context(configuration: self.configuration,
                                                  clientSettings: []))
-            urlSession.expect("https://example.com/.well-known/openid-configuration",
-                              data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
-                              contentType: "application/json")
-            urlSession.expect("https://example.com/oauth2/v1/introspect", data: nil, statusCode: 401)
-            let expect = expectation(description: "network request")
-            client.introspect(token: token, type: .refreshToken) { result in
-                switch result {
-                case .success:
-                    XCTFail()
-                case .failure(let error):
-                    XCTAssertNotNil(error)
-                    XCTAssertEqual(error.localizedDescription,
-                                   OAuth2Error.network(error: APIClientError.missingResponse).localizedDescription)
-                }
-                expect.fulfill()
+        urlSession.expect("https://example.com/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/introspect", data: nil, statusCode: 401)
+        let expect = expectation(description: "network request")
+        client.introspect(token: token, type: .refreshToken) { result in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                XCTAssertNotNil(error)
+                XCTAssertEqual(error.localizedDescription,
+                               OAuth2Error.network(error: APIClientError.missingResponse).localizedDescription)
             }
-
-            waitForExpectations(timeout: 1.0) { error in
-                XCTAssertNil(error)
-            }
+            expect.fulfill()
         }
+        
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+    }
  
     func testRevoke() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",


### PR DESCRIPTION
Some API responses may use status codes to indicate error states that are still actionable, accompanied by a response body. This update enables developers to customize response handling to ensure those bodies are still consumable.