### PR TITLE
Resolve issue where the compiler is confused between Swift Concurrency and Block-based functions

### DIFF
--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -185,14 +185,14 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     
     /// Attempt to refresh the token.
     /// - Parameter completion: Completion block invoked when a result is returned.
-    public func refresh(completion: ((Result<Void, OAuth2Error>) -> Void)? = nil) {
+    public func refresh(completion: @escaping (Result<Void, OAuth2Error>) -> Void) {
         oauth2.refresh(token) { result in
             switch result {
             case .success(let token):
                 self.token = token
-                completion?(.success(()))
+                completion(.success(()))
             case .failure(let error):
-                completion?(.failure(error))
+                completion(.failure(error))
             }
         }
     }
@@ -200,14 +200,14 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     /// Attempt to refresh the token if it either has expired, or is about to expire.
     /// - Parameter completion: Completion block invoked to indicate the status of the token, if the refresh was successful or if an error occurred.
     public func refreshIfNeeded(graceInterval: TimeInterval = Credential.refreshGraceInterval,
-                                completion: ((Result<Void, OAuth2Error>) -> Void)? = nil)
+                                completion: @escaping (Result<Void, OAuth2Error>) -> Void)
     {
         if let expiresAt = token.expiresAt,
             expiresAt.timeIntervalSinceNow <= graceInterval
         {
             refresh(completion: completion)
         } else {
-            completion?(.success(()))
+            completion(.success(()))
         }
     }
     
@@ -227,7 +227,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     /// - Parameters:
     ///   - type: The token type to revoke, defaulting to `.all`.
     ///   - completion: Completion block called when the operation completes.
-    public func revoke(type: Token.RevokeType = .all, completion: ((Result<Void, OAuth2Error>) -> Void)? = nil) {
+    public func revoke(type: Token.RevokeType = .all, completion: ((Result<Void, OAuth2Error>) -> Void)?) {
         let shouldRemove = (type == .all ||
                             (type == .refreshToken && token.refreshToken != nil) ||
                             type == .accessToken)
@@ -254,9 +254,9 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     
     /// Introspect the token to check it for validity, and read the additional information associated with it.
     /// - Parameter completion: Completion block invoked when a result is returned.
-    public func introspect(_ type: Token.Kind, completion: ((Result<TokenInfo, OAuth2Error>) -> Void)? = nil) {
+    public func introspect(_ type: Token.Kind, completion: @escaping (Result<TokenInfo, OAuth2Error>) -> Void) {
         oauth2.introspect(token: token, type: type) { result in
-            completion?(result)
+            completion(result)
         }
     }
 
@@ -264,9 +264,9 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     ///
     /// In addition to passing the result to the provided completion block, a successful request will result in the ``Credential/userInfo`` property being set with the new value for later use.
     /// - Parameter completion: Optional completion block to be invoked when a result is returned.
-    public func userInfo(completion: ((Result<UserInfo, OAuth2Error>) -> Void)? = nil) {
+    public func userInfo(completion: @escaping (Result<UserInfo, OAuth2Error>) -> Void) {
         oauth2.userInfo(token: token) { result in
-            defer { completion?(result) }
+            defer { completion(result) }
             
             if case let .success(userInfo) = result {
                 self.userInfo = userInfo

--- a/Sources/AuthFoundation/User Management/Internal/Credential+Internal.swift
+++ b/Sources/AuthFoundation/User Management/Internal/Credential+Internal.swift
@@ -18,7 +18,7 @@ extension Credential {
             return nil
         }
         
-        refreshIfNeeded()
+        refreshIfNeeded { _ in }
         
         automaticRefreshTimer?.cancel()
         
@@ -31,7 +31,7 @@ extension Credential {
                              repeating: repeating)
         timerSource.setEventHandler { [weak self] in
             guard let self = self else { return }
-            self.refreshIfNeeded()
+            self.refreshIfNeeded { _ in }
         }
         
         return timerSource

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -185,8 +185,8 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
     ///
     /// The ``resume(with:completion:)`` method also uses this context, to poll the server to determine when the user approves the authorization request.
     /// - Parameters:
-    ///   - completion: Optional completion block for receiving the context. If `nil`, you may rely upon the ``DeviceAuthorizationFlowDelegate/authentication(flow:received:)`` method instead.
-    public func start(completion: ((Result<Context, APIClientError>) -> Void)? = nil) {
+    ///   - completion: Completion block for receiving the context.
+    public func start(completion: @escaping (Result<Context, OAuth2Error>) -> Void) {
         isAuthenticating = true
 
         client.openIdConfiguration { result in
@@ -194,7 +194,7 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
             case .success(let configuration):
                 guard let url = configuration.deviceAuthorizationEndpoint else {
                     self.delegateCollection.invoke { $0.authentication(flow: self, received: .invalidUrl) }
-                    completion?(.failure(.invalidUrl))
+                    completion(.failure(.invalidUrl))
                     return
                 }
                 
@@ -205,16 +205,17 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
                     switch result {
                     case .failure(let error):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: .network(error: error)) }
-                        completion?(.failure(error))
+                        completion(.failure(.network(error: error)))
                     case .success(let response):
                         self.context = response.result
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
-                        completion?(.success(response.result))
+                        completion(.success(response.result))
                     }
                 }
                 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
+                completion(.failure(error))
             }
         }
     }
@@ -224,8 +225,8 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
     /// Once an authentication session has begun, using ``start(completion:)``, the user should be presented with the user code and verification URI. This method is used to poll the server, to determine when a user completes authorizing this device. At that point, the result is exchanged for a token.
     /// - Parameters:
     ///   - context: Device authorization context object.
-    ///   - completion: Optional completion block for receiving the token, or error result. If `nil`, you may rely upon the ``DeviceAuthorizationFlowDelegate/authentication(flow:received:)`` method instead.
-    public func resume(with context: Context, completion: ((Result<Token, APIClientError>) -> Void)? = nil) {
+    ///   - completion: Completion block for receiving the token.
+    public func resume(with context: Context, completion: @escaping (Result<Token, OAuth2Error>) -> Void) {
         self.completion = completion
         scheduleTimer()
     }
@@ -243,7 +244,7 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
     static var slowDownInterval: TimeInterval = 5
     
     var timer: DispatchSourceTimer?
-    var completion: ((Result<Token, APIClientError>) -> Void)?
+    var completion: ((Result<Token, OAuth2Error>) -> Void)?
     public let delegateCollection = DelegateCollection<DeviceAuthorizationFlowDelegate>()
     
     func scheduleTimer(offsetBy interval: TimeInterval? = nil) {
@@ -265,7 +266,7 @@ public final class DeviceAuthorizationFlow: AuthenticationFlow {
                 switch result {
                 case .failure(let error):
                     self.reset()
-                    completion?(.failure(error))
+                    completion?(.failure(.network(error: error)))
                     
                 case .success(let token):
                     if let token = token {

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -83,7 +83,7 @@ public final class ResourceOwnerFlow: AuthenticationFlow {
     ///   - username: Username
     ///   - password: Password
     ///   - completion: Completion invoked when a response is received.
-    public func start(username: String, password: String, completion: ((Result<Token, APIClientError>) -> Void)? = nil) {
+    public func start(username: String, password: String, completion: @escaping (Result<Token, OAuth2Error>) -> Void) {
         isAuthenticating = true
 
         client.openIdConfiguration { result in
@@ -100,15 +100,16 @@ public final class ResourceOwnerFlow: AuthenticationFlow {
                     switch result {
                     case .failure(let error):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: .network(error: error)) }
-                        completion?(.failure(error))
+                        completion(.failure(.network(error: error)))
                     case .success(let response):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
-                        completion?(.success(response.result))
+                        completion(.success(response.result))
                     }
                 }
 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
+                completion(.failure(error))
             }
         }
     }

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -103,7 +103,7 @@ public final class SessionTokenFlow: AuthenticationFlow {
     ///   - completion: Completion invoked when a response is received.
     public func start(with sessionToken: String,
                       context: AuthorizationCodeFlow.Context? = nil,
-                      completion: ((Result<Token, OAuth2Error>) -> Void)? = nil)
+                      completion: @escaping (Result<Token, OAuth2Error>) -> Void)
     {
         isAuthenticating = true
 
@@ -117,7 +117,7 @@ public final class SessionTokenFlow: AuthenticationFlow {
             switch result {
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
-                completion?(.failure(error))
+                completion(.failure(error))
             case .success(let response):
                 self.complete(using: flow, url: response) { result in
                     self.reset()
@@ -125,10 +125,10 @@ public final class SessionTokenFlow: AuthenticationFlow {
                     switch result {
                     case .failure(let error):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
-                        completion?(.failure(error))
+                        completion(.failure(error))
                     case .success(let response):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response) }
-                        completion?(.success(response))
+                        completion(.success(response))
                     }
                 }
             }

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -106,11 +106,11 @@ public final class TokenExchangeFlow: AuthenticationFlow {
     /// This method is used to begin a token exchange.  This method is asynchronous, and will invoke the appropriate delegate methods when a response is received.
     /// - Parameters:
     ///   - tokens: Tokens to exchange.
-    ///   - completion: Optional completion block for receiving the response. If `nil`, you may rely upon the appropriate delegate API methods.
-    public func start(with tokens: [TokenType], completion: ((Result<Token, OAuth2Error>) -> Void)? = nil) {
+    ///   - completion: Completion block for receiving the response.
+    public func start(with tokens: [TokenType], completion: @escaping (Result<Token, OAuth2Error>) -> Void) {
         guard !tokens.isEmpty else {
             delegateCollection.invoke { $0.authentication(flow: self, received: OAuth2Error.cannotComposeUrl) }
-            completion?(.failure(OAuth2Error.cannotComposeUrl))
+            completion(.failure(OAuth2Error.cannotComposeUrl))
             
             return
         }
@@ -130,10 +130,10 @@ public final class TokenExchangeFlow: AuthenticationFlow {
                     case .failure(let error):
                         let oauthError = OAuth2Error.error(error)
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: oauthError) }
-                        completion?(.failure(oauthError))
+                        completion(.failure(oauthError))
                     case .success(let response):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
-                        completion?(.success(response.result))
+                        completion(.success(response.result))
                     }
                     
                     self.isAuthenticating = false
@@ -141,6 +141,7 @@ public final class TokenExchangeFlow: AuthenticationFlow {
                 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
+                completion(.failure(error))
             }
         }
     }

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
@@ -139,7 +139,7 @@ public final class SessionLogoutFlow: LogoutFlow {
     /// - Parameters:
     ///   - idToken: The ID token string.
     ///   - completion: Optional completion block for receiving the response. If `nil`, you may rely upon the appropriate delegate API methods.
-    public func start(idToken: String, completion: ((Result<URL, OAuth2Error>) -> Void)? = nil) throws {
+    public func start(idToken: String, completion: @escaping (Result<URL, OAuth2Error>) -> Void) throws {
         try start(with: Context(idToken: idToken), completion: completion)
     }
 
@@ -149,9 +149,9 @@ public final class SessionLogoutFlow: LogoutFlow {
     /// - Parameters:
     ///   - context: Represents current state for a logout session.
     ///   - completion: Optional completion block for receiving the response. If `nil`, you may rely upon the appropriate delegate API methods.
-    public func start(with context: Context, completion: ((Result<URL, OAuth2Error>) -> Void)? = nil) throws {
+    public func start(with context: Context, completion: @escaping (Result<URL, OAuth2Error>) -> Void) throws {
         guard !inProgress else {
-            completion?(.failure(.missingClientConfiguration))
+            completion(.failure(.missingClientConfiguration))
             return
         }
         
@@ -163,7 +163,7 @@ public final class SessionLogoutFlow: LogoutFlow {
             switch result {
             case .failure(let error):
                 self.delegateCollection.invoke { $0.logout(flow: self, received: error) }
-                completion?(.failure(error))
+                completion(.failure(error))
             case .success(let configuration):
                 do {
                     guard let endSessionEndpoint = configuration.endSessionEndpoint else {
@@ -176,11 +176,11 @@ public final class SessionLogoutFlow: LogoutFlow {
                     context.logoutURL = url
                     self.context = context
                     
-                    completion?(.success(url))
+                    completion(.success(url))
                 } catch {
                     let oauthError = error as? OAuth2Error ?? .error(error)
                     self.delegateCollection.invoke { $0.logout(flow: self, received: oauthError) }
-                    completion?(.failure(oauthError))
+                    completion(.failure(oauthError))
                 }
             }
         }

--- a/Sources/WebAuthenticationUI/Providers/AuthenticationServicesProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/AuthenticationServicesProvider.swift
@@ -68,7 +68,7 @@ class AuthenticationServicesProvider: NSObject, WebAuthenticationProvider {
     }
 
     func start(context: AuthorizationCodeFlow.Context? = nil) {
-        loginFlow.start(with: context)
+        loginFlow.start(with: context) { _ in }
     }
     
     func createSession(url: URL, callbackURLScheme: String?, completionHandler: @escaping ASWebAuthenticationSession.CompletionHandler) -> AuthenticationServicesProviderSession {
@@ -103,7 +103,7 @@ class AuthenticationServicesProvider: NSObject, WebAuthenticationProvider {
         }
 
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow.start(with: context)
+        try? logoutFlow.start(with: context) { _ in }
     }
     
     func logout(using url: URL) {
@@ -173,7 +173,7 @@ class AuthenticationServicesProvider: NSObject, WebAuthenticationProvider {
         }
         
         do {
-            try loginFlow.resume(with: url)
+            try loginFlow.resume(with: url) { _ in }
         } catch {
             received(error: .authenticationProviderError(error))
         }

--- a/Sources/WebAuthenticationUI/Providers/SafariBrowserProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/SafariBrowserProvider.swift
@@ -82,7 +82,7 @@ final class SafariBrowserProvider: NSObject, WebAuthenticationProvider {
     }
     
     func start(context: AuthorizationCodeFlow.Context?) {
-        loginFlow.start(with: context)
+        loginFlow.start(with: context) { _ in }
     }
     
     func logout(context: SessionLogoutFlow.Context) {
@@ -91,7 +91,7 @@ final class SafariBrowserProvider: NSObject, WebAuthenticationProvider {
         }
 
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow.start(with: context)
+        try? logoutFlow.start(with: context) { _ in }
     }
     
     func cancel() {

--- a/Sources/WebAuthenticationUI/Providers/SafariServicesProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/SafariServicesProvider.swift
@@ -44,12 +44,12 @@ final class SafariServicesProvider: NSObject, WebAuthenticationProvider {
     }
     
     func start(context: AuthorizationCodeFlow.Context?) {
-        loginFlow.start(with: context)
+        loginFlow.start(with: context) { _ in }
     }
     
     func logout(context: SessionLogoutFlow.Context) {
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow?.start(with: context)
+        try? logoutFlow?.start(with: context) { _ in }
     }
     
     func authenticate(using url: URL) {
@@ -100,7 +100,7 @@ final class SafariServicesProvider: NSObject, WebAuthenticationProvider {
         }
         
         do {
-            try loginFlow.resume(with: url)
+            try loginFlow.resume(with: url) { _ in }
         } catch {
             received(error: .authenticationProviderError(error))
         }


### PR DESCRIPTION
The block-based methods currently have optional blocks, based on the idea that delegates would be used to intercept these responses, but to date it appears that this feature is never used. In practice however, this results in the compiler confusing which function should be invoked. For example:

```
let token = try await flow.start()
```

vs
```
flow.start()
```

The first one should use Swift Concurrency, while the second should use the block methods. However, in practice, in recent versions of Swift, the compiler assumes that the first example should use a non-async function, with a default nil completion block.

To address this, the completion block is being changed to nonnull, to make it explicit which function should be invoked by the compiler.