### PR TITLE
Add option to test revoke within the sample app, and improve shouldRemove handling

### DIFF
--- a/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
@@ -254,7 +254,7 @@ class ProfileTableViewController: UITableViewController {
         switch segue.identifier {
         case "TokenDetail":
             guard let target = segue.destination as? TokenDetailViewController else { break }
-            target.token = Credential.default?.token
+            target.credential = Credential.default
 
         default: break
         }

--- a/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
@@ -14,7 +14,7 @@ import UIKit
 import OktaOAuth2
 
 class TokenDetailViewController: UIViewController {
-    var token: Token? {
+    var credential: Credential? {
         didSet {
             DispatchQueue.main.async {
                 self.drawToken()
@@ -30,14 +30,55 @@ class TokenDetailViewController: UIViewController {
         NotificationCenter.default.addObserver(forName: .defaultCredentialChanged,
                                                object: nil,
                                                queue: .main) { (notification) in
-            guard let user = notification.object as? Credential else { return }
-            self.token = user.token
+            guard let credential = notification.object as? Credential else { return }
+            self.credential = credential
         }
-        token = Credential.default?.token
+        credential = Credential.default
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Revoke", style: .plain, target: self, action: #selector(revokeAction(_:)))
     }
     
+    @objc
+    func revokeAction(_ sender: Any) {
+        let alert = UIAlertController(title: "Revoke Tokens", message: nil, preferredStyle: .actionSheet)
+    
+        let names: [(String, Token.RevokeType)] = [
+            ("Access Token", .accessToken),
+            ("Refresh Token", .refreshToken),
+            ("Device Secret", .deviceSecret),
+            ("All Tokens", .all)
+        ]
+    
+        for (name, type) in names {
+            alert.addAction(.init(title: name, style: .destructive) { _ in
+                self.revoke(type)
+            })
+        }
+    
+        alert.addAction(.init(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+    
+    func revoke(_ kind: Token.RevokeType) {
+        guard let credential = credential else { return }
+        let busyAlert = UIAlertController(title: "Revoking", message: nil, preferredStyle: .alert)
+        present(busyAlert, animated: true)
+    
+        credential.revoke(type: kind) { result in
+            DispatchQueue.main.async {
+                busyAlert.dismiss(animated: true) {
+                    guard case let .failure(error) = result else { return }
+    
+                    let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+                    alert.addAction(.init(title: "OK", style: .default))
+                    self.present(alert, animated: true)
+                }
+            }
+        }
+    }
+
     func drawToken() {
-        guard let token = token else {
+        guard let token = credential?.token else {
             textView.text = "No token was found"
             return
         }
@@ -56,15 +97,15 @@ class TokenDetailViewController: UIViewController {
         }
         
         let string = NSMutableAttributedString()
+        addString(to: string, title: "Expires in", value: "\(token.expiresIn) seconds")
+        addString(to: string, title: "Scope", value: token.scope ?? "N/A")
+        addString(to: string, title: "Token type", value: token.tokenType)
+        
         addString(to: string, title: "Access token", value: token.accessToken)
         
         if let refreshToken = token.refreshToken {
             addString(to: string, title: "Refresh token", value: refreshToken)
         }
-        
-        addString(to: string, title: "Expires in", value: "\(token.expiresIn) seconds")
-        addString(to: string, title: "Scope", value: token.scope ?? "N/A")
-        addString(to: string, title: "Token type", value: token.tokenType)
         
         if let idToken = token.idToken {
             addString(to: string, title: "ID token", value: idToken.rawValue)

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -228,9 +228,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     ///   - type: The token type to revoke, defaulting to `.all`.
     ///   - completion: Completion block called when the operation completes.
     public func revoke(type: Token.RevokeType = .all, completion: ((Result<Void, OAuth2Error>) -> Void)?) {
-        let shouldRemove = (type == .all ||
-                            (type == .refreshToken && token.refreshToken != nil) ||
-                            type == .accessToken && token.refreshToken == nil)
+        let shouldRemove = shouldRemove(for: type)
         
         oauth2.revoke(token, type: type) { result in
             defer { completion?(result) }

--- a/Sources/AuthFoundation/User Management/Internal/Credential+Internal.swift
+++ b/Sources/AuthFoundation/User Management/Internal/Credential+Internal.swift
@@ -36,4 +36,10 @@ extension Credential {
         
         return timerSource
     }
+    
+    func shouldRemove(for type: Token.RevokeType) -> Bool {
+        type == .all ||
+        (type == .refreshToken && token.refreshToken != nil) ||
+        (type == .accessToken && token.refreshToken == nil)
+    }
 }

--- a/Tests/AuthFoundationTests/CredentialInternalTests.swift
+++ b/Tests/AuthFoundationTests/CredentialInternalTests.swift
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import TestCommon
+@testable import AuthFoundation
+
+final class CredentialInternalTests: XCTestCase {
+    var coordinator: MockCredentialCoordinator!
+
+    override func setUpWithError() throws {
+        coordinator = MockCredentialCoordinator()
+    }
+    
+    override func tearDownWithError() throws {
+        coordinator = nil
+    }
+
+    func testShouldRemoveWithOnlyAccessToken() throws {
+        let credential = coordinator.credential(with: [])
+        XCTAssertTrue(credential.shouldRemove(for: .all))
+        XCTAssertTrue(credential.shouldRemove(for: .accessToken))
+        XCTAssertFalse(credential.shouldRemove(for: .refreshToken))
+        XCTAssertFalse(credential.shouldRemove(for: .deviceSecret))
+    }
+
+    func testShouldRemoveWithAccessAndRefreshToken() throws {
+        let credential = coordinator.credential(with: [.refreshToken])
+        XCTAssertTrue(credential.shouldRemove(for: .all))
+        XCTAssertFalse(credential.shouldRemove(for: .accessToken))
+        XCTAssertTrue(credential.shouldRemove(for: .refreshToken))
+        XCTAssertFalse(credential.shouldRemove(for: .deviceSecret))
+    }
+
+    func testShouldRemoveWithAccessAndDeviceToken() throws {
+        let credential = coordinator.credential(with: [.deviceSecret])
+        XCTAssertTrue(credential.shouldRemove(for: .all))
+        XCTAssertTrue(credential.shouldRemove(for: .accessToken))
+        XCTAssertFalse(credential.shouldRemove(for: .refreshToken))
+        XCTAssertFalse(credential.shouldRemove(for: .deviceSecret))
+    }
+
+    func testShouldRemoveWithAccessRefreshAndDeviceToken() throws {
+        let credential = coordinator.credential(with: [.refreshToken, .deviceSecret])
+        XCTAssertTrue(credential.shouldRemove(for: .all))
+        XCTAssertFalse(credential.shouldRemove(for: .accessToken))
+        XCTAssertTrue(credential.shouldRemove(for: .refreshToken))
+        XCTAssertFalse(credential.shouldRemove(for: .deviceSecret))
+    }
+}

--- a/Tests/TestCommon/MockCredentialCoordinator.swift
+++ b/Tests/TestCommon/MockCredentialCoordinator.swift
@@ -24,4 +24,9 @@ class MockCredentialCoordinator: CredentialCoordinator {
     
     func observe(oauth2 client: OAuth2Client) {
     }
+    
+    
+    func credential(with options: [Token.MockOptions] = []) -> Credential {
+        credentialDataSource.credential(for: Token.token(with: options), coordinator: self)
+    }
 }

--- a/Tests/TestCommon/MockToken.swift
+++ b/Tests/TestCommon/MockToken.swift
@@ -14,6 +14,12 @@ import Foundation
 @testable import AuthFoundation
 
 extension Token {
+    enum MockOptions {
+        case refreshToken
+        case deviceSecret
+        case idToken
+    }
+
     static let mockConfiguration = OAuth2Client.Configuration(
         baseURL: URL(string: "https://example.com")!,
         clientId: "0oa3en4fIMQ3ddc204w5",
@@ -41,4 +47,40 @@ extension Token {
               context: .init(configuration: mockConfiguration,
                              clientSettings: clientSettings))
     }
+    
+    static func token(with options: [MockOptions] = []) -> Token {
+        var scopes = "openid"
+        
+        var refreshToken: String? = nil
+        if options.contains(.refreshToken) {
+            refreshToken = "refresh123"
+            scopes += " offline_access"
+        }
+        
+        var deviceSecret: String? = nil
+        if options.contains(.deviceSecret) {
+            deviceSecret = "device123"
+            scopes += " device_sso"
+        }
+        
+        var idToken: JWT? = nil
+        if options.contains(.idToken) {
+            idToken = try! JWT(JWT.mockIDToken)
+        }
+        
+        return Token(id: "TokenId",
+                     issuedAt: Date(),
+                     tokenType: "Bearer",
+                     expiresIn: 300,
+                     accessToken: JWT.mockAccessToken,
+                     scope: scopes,
+                     refreshToken: refreshToken,
+                     idToken: idToken,
+                     deviceSecret: deviceSecret,
+                     context: Token.Context(configuration: .init(baseURL: URL(string: "https://example.com/oauth2/default")!,
+                                                                 clientId: "clientid",
+                                                                 scopes: scopes),
+                                            clientSettings: [ "client_id": "clientid" ]))
+    }
+
 }


### PR DESCRIPTION
In response to #115 I added features to demonstrate token revocation, to simplify debugging.
