### PR TITLE
Improve adding additional parameters during sign in / out

### DIFF
--- a/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
@@ -169,8 +169,13 @@ class ProfileTableViewController: UITableViewController {
         
         #if !os(tvOS) && canImport(WebAuthenticationUI) && !WEB_AUTH_DISABLED
         if let token = Credential.default?.token {
+            var options: [WebAuthentication.Option]?
+            options = []
+            // TODO: Uncomment the following line to force a user to sign in again while signing out.
+            // options = [.prompt(.login)]
+            
             alert.addAction(.init(title: "End a session", style: .destructive) { _ in
-                WebAuthentication.shared?.signOut(token: token) { result in
+                WebAuthentication.shared?.signOut(token: token, options: options) { result in
                     switch result {
                     case .success:
                         try? Keychain.deleteTokens()

--- a/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SignInViewController.swift
+++ b/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SignInViewController.swift
@@ -18,6 +18,10 @@ class SignInViewController: UIViewController {
     @IBOutlet weak var clientIdLabel: UILabel!
 
     let auth = WebAuthentication.shared
+    let options: [WebAuthentication.Option]? = [
+        // .login(hint: "jane.doe@example.com"),
+        // .prompt(.login)
+    ]
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,7 +55,7 @@ class SignInViewController: UIViewController {
 
     @IBAction func signIn(_ sender: Any) {
         let window = viewIfLoaded?.window
-        auth?.signIn(from: window) { result in
+        auth?.signIn(from: window, options: options) { result in
             switch result {
             case .success(let token):
                 do {

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -65,7 +65,7 @@ public protocol AuthorizationCodeFlowDelegate: AuthenticationDelegate {
 /// let redirectUri: URL
 /// let token = try await flow.resume(with: redirectUri)
 /// ```
-public final class AuthorizationCodeFlow: AuthenticationFlow {
+public class AuthorizationCodeFlow: AuthenticationFlow {
     /// A model representing the context and current state for an authorization session.
     public struct Context: Equatable {
         /// The `PKCE` credentials to use in the authorization request.
@@ -106,8 +106,8 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
     
     /// Errors reported during processing and handling of redirect URLs.
     ///
-    /// These errors are mostly reported as a result of the ``start(with:completion:)`` or ``start(with:)`` methods.
-    public enum RedirectError: Error {
+    /// These errors are mostly reported as a result of the ``start(with:additionalParameters:completion:)`` or ``start(with:additionalParameters:)`` methods.
+    public enum RedirectError: Error, Equatable {
         case invalidRedirectUrl
         case unexpectedScheme(_ scheme: String?)
         case missingQueryArguments
@@ -255,7 +255,7 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
     
     /// Continues an authentication flow using the given authentication redirect URI.
     ///
-    /// Once the user completes authorization, using the URL provided by the ``start(with:completion:)`` method within a browser, the browser will redirect to a URL that matches the scheme provided in the client configuration's ``redirectUri``. This URI will contain either an error response from the authorization server, or an authorization code which can be used to exchange a token.
+    /// Once the user completes authorization, using the URL provided by the ``start(with:additionalParameters:completion:)`` method within a browser, the browser will redirect to a URL that matches the scheme provided in the client configuration's ``redirectUri``. This URI will contain either an error response from the authorization server, or an authorization code which can be used to exchange a token.
     ///
     /// This method takes the returned redirect URI, and communicates with Okta to exchange that for a token.
     /// - Parameters:
@@ -325,7 +325,7 @@ extension AuthorizationCodeFlow {
     
     /// Asynchronously continues an authentication flow using the given authentication redirect URI, using Swift Concurrency.
     ///
-    /// Once the user completes authorization, using the URL provided by the ``start(with:)`` method within a browser, the browser will redirect to a URL that matches the scheme provided in the client configuration's ``redirectUri``. This URI will contain either an error response from the authorization server, or an authorization code which can be used to exchange a token.
+    /// Once the user completes authorization, using the URL provided by the ``start(with:additionalParameters:)`` method within a browser, the browser will redirect to a URL that matches the scheme provided in the client configuration's ``redirectUri``. This URI will contain either an error response from the authorization server, or an authorization code which can be used to exchange a token.
     ///
     /// This method takes the returned redirect URI, and communicates with Okta to exchange that for a token.
     /// - Parameters:

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -153,9 +153,10 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
     /// Convenience initializer to construct an authentication flow from variables.
     /// - Parameters:
     ///   - issuer: The issuer URL.
-    ///   - clientId: The client ID
-    ///   - scopes: The scopes to request
+    ///   - clientId: The client ID.
+    ///   - scopes: The scopes to request.
     ///   - redirectUri: The redirect URI for the client.
+    ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
     public convenience init(issuer: URL,
                             clientId: String,
                             scopes: String,
@@ -171,7 +172,8 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
     
     /// Initializer to construct an authentication flow from a pre-defined configuration and client.
     /// - Parameters:
-    ///   - configuration: The configuration to use for this authentication flow.
+    ///   - redirectUri: The redirect URI for the client.
+    ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
     ///   - client: The `OAuth2Client` to use with this flow.
     public init(redirectUri: URL,
                 additionalParameters: [String: String]? = nil,
@@ -215,8 +217,12 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
     /// This method is used to begin an authentication session. It is asynchronous, and will invoke the appropriate delegate methods when a response is received.
     /// - Parameters:
     ///   - context: Optional context to provide when customizing the state parameter.
+    ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
     ///   - completion: Completion block for receiving the response.
-    public func start(with context: Context? = nil, completion: @escaping (Result<URL, OAuth2Error>) -> Void) {
+    public func start(with context: Context? = nil,
+                      additionalParameters: [String: String]? = nil,
+                      completion: @escaping (Result<URL, OAuth2Error>) -> Void)
+    {
         var context = context ?? Context()
         isAuthenticating = true
 
@@ -230,7 +236,8 @@ public final class AuthorizationCodeFlow: AuthenticationFlow {
             case .success(let configuration):
                 do {
                     let url = try self.createAuthenticationURL(from: configuration.authorizationEndpoint,
-                                                               using: context)
+                                                               using: context,
+                                                               additionalParameters: additionalParameters)
                     context.authenticationURL = url
                     self.context = context
                     
@@ -306,10 +313,11 @@ extension AuthorizationCodeFlow {
     /// This method is used to begin an authentication session.
     /// - Parameters:
     ///   - context: Optional context to provide when customizing the state parameter.
+    ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
     /// - Returns: The URL a user should be presented with within a browser, to continue authorization.
-    public func start(with context: Context? = nil) async throws -> URL {
+    public func start(with context: Context? = nil, additionalParameters: [String: String]? = nil) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            start(with: context) { result in
+            start(with: context, additionalParameters: additionalParameters) { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -63,7 +63,7 @@ public protocol DeviceAuthorizationFlowDelegate: AuthenticationDelegate {
 /// // the code.
 /// let token = try await flow.resume(with: context)
 /// ```
-public final class DeviceAuthorizationFlow: AuthenticationFlow {
+public class DeviceAuthorizationFlow: AuthenticationFlow {
     /// A model representing the context and current state for an authorization session.
     public struct Context: Decodable, Equatable, Expires {
         let deviceCode: String

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -18,7 +18,7 @@ import AuthFoundation
 /// This simple authentication flow permits a suer to authenticate using a simple username and password. As such, the configuration is straightforward.
 ///
 /// > Important: Resource Owner authentication does not support MFA or other more secure authentication models, and is not recommended for production applications.
-public final class ResourceOwnerFlow: AuthenticationFlow {
+public class ResourceOwnerFlow: AuthenticationFlow {
     /// The OAuth2Client this authentication flow will use.
     public let client: OAuth2Client
     

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -16,7 +16,7 @@ import AuthFoundation
 /// An authentication flow class that exchanges a Session Token for access tokens.
 ///
 /// This flow is typically used in conjunction with the [classic Okta native authentication library](https://github.com/okta/okta-auth-swift). For native authentication using the Okta Identity Engine (OIE), please use the [Okta IDX library](https://github.com/okta/okta-idx-swift).
-public final class SessionTokenFlow: AuthenticationFlow {
+public class SessionTokenFlow: AuthenticationFlow {
     /// The OAuth2Client this authentication flow will use.
     public let client: OAuth2Client
     

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -14,7 +14,7 @@ import AuthFoundation
 import Foundation
 
 /// An authentication flow class that implements the Token Exchange Flow.
-public final class TokenExchangeFlow: AuthenticationFlow {
+public class TokenExchangeFlow: AuthenticationFlow {
     /// Identifies the audience of the authorization server.
     public enum Audience {
         case `default`

--- a/Sources/OktaOAuth2/Extensions/ErrorExtensions.swift
+++ b/Sources/OktaOAuth2/Extensions/ErrorExtensions.swift
@@ -12,6 +12,25 @@
 
 import Foundation
 
+extension AuthorizationCodeFlow.RedirectError {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidRedirectUrl, .invalidRedirectUrl): return true
+        case (.missingQueryArguments, .missingQueryArguments): return true
+        case (.missingAuthorizationCode, .missingAuthorizationCode): return true
+            
+        case (.unexpectedScheme(let lhsValue), .unexpectedScheme(let rhsValue)):
+            return lhsValue == rhsValue
+            
+        case (.invalidState(let lhsValue), .invalidState(let rhsValue)):
+            return lhsValue == rhsValue
+            
+        default:
+            return false
+        }
+    }
+}
+    
 extension AuthenticationError: LocalizedError {
     public var errorDescription: String? {
         switch self {

--- a/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
+++ b/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+// TODO: Remove on the next major release.
+extension WebAuthentication {
+    @available(*, deprecated, renamed: "signIn(from:options:completion:)")
+    public final func signIn(from window: WindowAnchor?,
+                             additionalParameters: [String: String]?,
+                             completion: @escaping (Result<Token, WebAuthenticationError>) -> Void)
+    {
+        signIn(from: window, options: options(from: additionalParameters), completion: completion)
+    }
+
+    @available(*, deprecated, renamed: "signOut(from:credential:options:completion:)")
+    public final func signOut(from window: WindowAnchor? = nil,
+                              credential: Credential? = .default,
+                              additionalParameters: [String: String]?,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
+        signOut(from: window, credential: credential, options: options(from: additionalParameters), completion: completion)
+    }
+    
+    @available(*, deprecated, renamed: "signOut(from:token:options:completion:)")
+    public final func signOut(from window: WindowAnchor? = nil,
+                              token: Token,
+                              additionalParameters: [String: String]?,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
+        signOut(from: window, token: token, options: options(from: additionalParameters), completion: completion)
+    }
+    
+    @available(*, deprecated, renamed: "signOut(from:token:options:completion:)")
+    public final func signOut(from window: WindowAnchor? = nil,
+                              token: String,
+                              additionalParameters: [String: String]?,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
+        signOut(from: window, token: token, options: options(from: additionalParameters), completion: completion)
+    }
+    
+    fileprivate func options(from additionalParameters: [String: String]?) -> [WebAuthentication.Option]? {
+        return additionalParameters?.reduce(into: [WebAuthentication.Option]()) { (result, item) in
+            switch item.key {
+            case "login_hint":
+                result.append(.login(hint: item.value))
+            case "display":
+                result.append(.display(item.value))
+            case "idp":
+                guard let url = URL(string: item.value) else { return }
+                result.append(.idp(url: url))
+            case "idp_scope":
+                result.append(.idpScope(item.value))
+            case "prompt":
+                let prompt: WebAuthentication.Option.Prompt
+                switch item.value {
+                case "none":
+                    prompt = .none
+                case "consent":
+                    prompt = .consent
+                case "login":
+                    prompt = .login
+                case "login consent", "consent login":
+                    prompt = .loginAndConsent
+                default:
+                    return
+                }
+                result.append(.prompt(prompt))
+            case "max_age":
+                let age: TimeInterval
+                if #available(iOS 15.0, *) {
+                    guard let value = try? TimeInterval(item.value, format: .number) else { return }
+                    age = value
+                } else {
+                    guard let value = Double(item.value) else { return }
+                    age = TimeInterval(value)
+                }
+                
+                result.append(.maxAge(age))
+            default:
+                result.append(.custom(key: item.key, value: item.value))
+            }
+        }
+    }
+}
+
+#if swift(>=5.5.1)
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+extension WebAuthentication {
+    @available(*, deprecated, renamed: "signIn(from:options:)")
+    public final func signIn(from window: WindowAnchor?,
+                             additionalParameters: [String: String]?) async throws -> Token
+    {
+        try await signIn(from: window, options: options(from: additionalParameters))
+    }
+    
+    @available(*, deprecated, renamed: "signOut(from:credential:options:)")
+    public final func signOut(from window: WindowAnchor?,
+                              credential: Credential? = .default,
+                              additionalParameters: [String: String]?) async throws
+    {
+        try await signOut(from: window, credential: credential, options: options(from: additionalParameters))
+    }
+    
+    @available(*, deprecated, renamed: "signOut(from:token:options:)")
+    public final func signOut(from window: WindowAnchor?,
+                              token: Token,
+                              additionalParameters: [String: String]?) async throws
+    {
+        try await signOut(from: window, token: token, options: options(from: additionalParameters))
+    }
+    
+    @available(*, deprecated, renamed: "signOut(from:token:options:)")
+    public final func signOut(from window: WindowAnchor?,
+                              token: String,
+                              additionalParameters: [String: String]?) async throws
+    {
+        try await signOut(from: window, token: token, options: options(from: additionalParameters))
+    }
+}
+#endif

--- a/Sources/WebAuthenticationUI/Internal/Options+Extensions.swift
+++ b/Sources/WebAuthenticationUI/Internal/Options+Extensions.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+import OktaOAuth2
+
+extension WebAuthentication.Option {
+    var queryItems: [String: String] {
+        switch self {
+        case .login(hint: let username):
+            return ["login_hint": username]
+        case .display(let value):
+            return ["display": value]
+        case .idp(url: let url):
+            return ["idp": url.absoluteString]
+        case .idpScope(let scope):
+            return ["idp_scope": scope]
+        case .prompt(let value):
+            return ["prompt": value.rawValue]
+        case .custom(key: let key, value: let value):
+            return [key: value]
+        case .maxAge(_), .state(_):
+            return [:]
+        }
+    }
+}
+
+extension Collection where Element == WebAuthentication.Option {
+    var additionalParameters: [String: String] {
+        map { $0.queryItems }
+            .reduce([:]) { $0.merging($1) { current, _ in current }}
+    }
+    
+    var state: String? {
+        guard case let .state(state) = filter({
+            switch $0 {
+            case .state(_):
+                return true
+            default:
+                return false
+            }
+        }).first else {
+            return nil
+        }
+        
+        return state
+    }
+    
+    var maxAge: TimeInterval? {
+        guard case let .maxAge(result) = filter({
+            switch $0 {
+            case .maxAge(_):
+                return true
+            default:
+                return false
+            }
+        }).first else {
+            return nil
+        }
+        
+        return result
+    }
+    
+    var context: AuthorizationCodeFlow.Context? {
+        let state = self.state
+        let maxAge = self.maxAge
+        
+        guard state != nil || maxAge != nil else {
+            return nil
+        }
+        
+        return .init(state: state, maxAge: maxAge)
+    }
+}

--- a/Sources/WebAuthenticationUI/Providers/AuthenticationServicesProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/AuthenticationServicesProvider.swift
@@ -67,8 +67,8 @@ class AuthenticationServicesProvider: NSObject, WebAuthenticationProvider {
         self.logoutFlow?.remove(delegate: self)
     }
 
-    func start(context: AuthorizationCodeFlow.Context? = nil) {
-        loginFlow.start(with: context) { _ in }
+    func start(context: AuthorizationCodeFlow.Context?, additionalParameters: [String: String]?) {
+        loginFlow.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
     func createSession(url: URL, callbackURLScheme: String?, completionHandler: @escaping ASWebAuthenticationSession.CompletionHandler) -> AuthenticationServicesProviderSession {
@@ -97,13 +97,13 @@ class AuthenticationServicesProvider: NSObject, WebAuthenticationProvider {
         }
     }
     
-    func logout(context: SessionLogoutFlow.Context) {
+    func logout(context: SessionLogoutFlow.Context, additionalParameters: [String: String]?) {
         guard let logoutFlow = logoutFlow else {
             return
         }
 
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow.start(with: context) { _ in }
+        try? logoutFlow.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
     func logout(using url: URL) {

--- a/Sources/WebAuthenticationUI/Providers/SafariBrowserProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/SafariBrowserProvider.swift
@@ -81,17 +81,17 @@ final class SafariBrowserProvider: NSObject, WebAuthenticationProvider {
         delegate?.authentication(provider: self, received: logoutError)
     }
     
-    func start(context: AuthorizationCodeFlow.Context?) {
-        loginFlow.start(with: context) { _ in }
+    func start(context: AuthorizationCodeFlow.Context?, additionalParameters: [String: String]?) {
+        loginFlow.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
-    func logout(context: SessionLogoutFlow.Context) {
+    func logout(context: SessionLogoutFlow.Context, additionalParameters: [String: String]?) {
         guard let logoutFlow = logoutFlow else {
             return
         }
 
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow.start(with: context) { _ in }
+        try? logoutFlow.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
     func cancel() {

--- a/Sources/WebAuthenticationUI/Providers/SafariServicesProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/SafariServicesProvider.swift
@@ -43,13 +43,13 @@ final class SafariServicesProvider: NSObject, WebAuthenticationProvider {
         self.logoutFlow?.remove(delegate: self)
     }
     
-    func start(context: AuthorizationCodeFlow.Context?) {
-        loginFlow.start(with: context) { _ in }
+    func start(context: AuthorizationCodeFlow.Context?, additionalParameters: [String: String]?) {
+        loginFlow.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
-    func logout(context: SessionLogoutFlow.Context) {
+    func logout(context: SessionLogoutFlow.Context, additionalParameters: [String: String]?) {
         // LogoutFlow invokes delegate, so an error is propagated from delegate method
-        try? logoutFlow?.start(with: context) { _ in }
+        try? logoutFlow?.start(with: context, additionalParameters: additionalParameters) { _ in }
     }
     
     func authenticate(using url: URL) {

--- a/Sources/WebAuthenticationUI/Providers/WebAuthenticationProvider.swift
+++ b/Sources/WebAuthenticationUI/Providers/WebAuthenticationProvider.swift
@@ -20,8 +20,8 @@ protocol WebAuthenticationProvider {
     var logoutFlow: SessionLogoutFlow? { get }
     var delegate: WebAuthenticationProviderDelegate? { get }
 
-    func start(context: AuthorizationCodeFlow.Context?)
-    func logout(context: SessionLogoutFlow.Context)
+    func start(context: AuthorizationCodeFlow.Context?, additionalParameters: [String: String]?)
+    func logout(context: SessionLogoutFlow.Context, additionalParameters: [String: String]?)
     func cancel()
 }
 

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -97,8 +97,12 @@ public class WebAuthentication {
     /// Starts sign-in using the configured client.
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
     ///   - completion: Completion block that will be invoked when authentication finishes.
-    public final func signIn(from window: WindowAnchor?, completion: @escaping (Result<Token, WebAuthenticationError>) -> Void) {
+    public final func signIn(from window: WindowAnchor?,
+                             additionalParameters: [String: String]? = nil,
+                             completion: @escaping (Result<Token, WebAuthenticationError>) -> Void)
+    {
         if provider != nil {
             cancel()
         }
@@ -110,43 +114,58 @@ public class WebAuthentication {
         self.completionBlock = completion
         self.provider = provider
 
-        provider?.start(context: context)
+        provider?.start(context: context, additionalParameters: additionalParameters)
     }
     
     /// Starts log-out using the credential.
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - credential: Stored credentials that will retrieve the ID token.
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
     ///   - completion: Completion block that will be invoked when log-out finishes.
-    public final func signOut(from window: WindowAnchor? = nil, credential: Credential? = .default, completion: @escaping (Result<Void, WebAuthenticationError>) -> Void) {
+    public final func signOut(from window: WindowAnchor? = nil,
+                              credential: Credential? = .default,
+                              additionalParameters: [String: String]? = nil,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
         guard let token = credential?.token else {
             completion(.failure(.missingIdToken))
             return
         }
         
-        signOut(from: window, token: token, completion: completion)
+        signOut(from: window, token: token, additionalParameters: additionalParameters, completion: completion)
     }
     
     /// Starts log-out using the `Token` object.
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - token: Token object that will retrieve the ID token.
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
     ///   - completion: Completion block that will be invoked when sign-out finishes.
-    public final func signOut(from window: WindowAnchor? = nil, token: Token, completion: @escaping (Result<Void, WebAuthenticationError>) -> Void) {
+    public final func signOut(from window: WindowAnchor? = nil,
+                              token: Token,
+                              additionalParameters: [String: String]? = nil,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
         guard let idToken = token.idToken else {
             completion(.failure(.missingIdToken))
             return
         }
         
-        signOut(from: window, token: idToken.rawValue, completion: completion)
+        signOut(from: window, token: idToken.rawValue, additionalParameters: additionalParameters, completion: completion)
     }
 
     /// Starts log-out using the ID token.
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - token: The ID token string used for log-out.
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
     ///   - completion: Completion block that will be invoked when sign-out finishes.
-    public final func signOut(from window: WindowAnchor? = nil, token: String, completion: @escaping (Result<Void, WebAuthenticationError>) -> Void) {
+    public final func signOut(from window: WindowAnchor? = nil,
+                              token: String,
+                              additionalParameters: [String: String]? = nil,
+                              completion: @escaping (Result<Void, WebAuthenticationError>) -> Void)
+    {
         var provider = provider
         
         if provider != nil {
@@ -162,7 +181,7 @@ public class WebAuthentication {
         self.provider = provider
         
         let context = SessionLogoutFlow.Context(idToken: token)
-        provider?.logout(context: context)
+        provider?.logout(context: context, additionalParameters: additionalParameters)
     }
     
     /// Cancels the authentication session.
@@ -239,7 +258,9 @@ public class WebAuthentication {
         
         let logoutFlow: SessionLogoutFlow?
         if let logoutRedirectUri = logoutRedirectUri {
-            logoutFlow = SessionLogoutFlow(logoutRedirectUri: logoutRedirectUri, client: client)
+            logoutFlow = SessionLogoutFlow(logoutRedirectUri: logoutRedirectUri,
+                                           additionalParameters: additionalParameters,
+                                           client: client)
         } else {
             logoutFlow = nil
         }
@@ -320,11 +341,15 @@ public class WebAuthentication {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension WebAuthentication {
     /// Asynchronously initiates authentication from the given window.
-    /// - Parameter window: The window from which the authentication browser should be shown.
+    /// - Parameters:
+    ///   - window: The window from which the authentication browser should be shown.
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
     /// - Returns: The token representing the signed-in user.
-    public final func signIn(from window: WindowAnchor?) async throws -> Token {
+    public final func signIn(from window: WindowAnchor?,
+                             additionalParameters: [String: String]? = nil) async throws -> Token
+    {
         try await withCheckedThrowingContinuation { continuation in
-            self.signIn(from: window) { continuation.resume(with: $0) }
+            self.signIn(from: window, additionalParameters: additionalParameters) { continuation.resume(with: $0) }
         }
     }
     
@@ -332,10 +357,13 @@ extension WebAuthentication {
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - credential: Stored credentials that will retrieve the ID token.
-    ///   - completion: Completion block that will be invoked when log-out finishes.
-    public final func signOut(from window: WindowAnchor?, credential: Credential? = .default) async throws {
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
+    public final func signOut(from window: WindowAnchor?,
+                              credential: Credential? = .default,
+                              additionalParameters: [String: String]? = nil) async throws
+    {
         try await withCheckedThrowingContinuation { continuation in
-            self.signOut(from: window, credential: credential) { continuation.resume(with: $0) }
+            self.signOut(from: window, credential: credential, additionalParameters: additionalParameters) { continuation.resume(with: $0) }
         }
     }
     
@@ -343,10 +371,13 @@ extension WebAuthentication {
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - token: Token object that will retrieve the ID token.
-    ///   - completion: Completion block that will be invoked when sign-out finishes.
-    public final func signOut(from window: WindowAnchor?, token: Token) async throws {
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
+    public final func signOut(from window: WindowAnchor?,
+                              token: Token,
+                              additionalParameters: [String: String]? = nil) async throws
+    {
         try await withCheckedThrowingContinuation { continuation in
-            self.signOut(from: window, token: token) { continuation.resume(with: $0) }
+            self.signOut(from: window, token: token, additionalParameters: additionalParameters) { continuation.resume(with: $0) }
         }
     }
     
@@ -354,10 +385,12 @@ extension WebAuthentication {
     /// - Parameters:
     ///   - window: Window from which the sign in process will be started.
     ///   - idToken: The ID token used for log-out.
-    ///   - completion: Completion block that will be invoked when sign-out finishes.
-    public final func signOut(from window: WindowAnchor?, token: String) async throws {
+    ///   - additionalParameters: Optional parameters to add to the authorization query string.
+    public final func signOut(from window: WindowAnchor?,
+                              token: String,
+                              additionalParameters: [String: String]? = nil) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            self.signOut(from: window, token: token) { continuation.resume(with: $0) }
+            self.signOut(from: window, token: token, additionalParameters: additionalParameters) { continuation.resume(with: $0) }
         }
     }
 }

--- a/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/CustomizingAuthorizationURL.md
+++ b/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/CustomizingAuthorizationURL.md
@@ -8,9 +8,27 @@ Many times the URL presented to the user within a browser may need to be customi
 
 Since this URL is typically generated at runtime, APIs are needed to give you the capability to configure this URL.
 
+## signIn and signOut Options
+
+The simplest approach to customizing your authorization URL is by specifying options when invoking the ``WebAuthentication/signIn(from:options:)`` or ``WebAuthentication/signOut(from:credential:options:)`` functions. These options are defined in the ``WebAuthentication/Option`` enumeration, and gives you control over the behavior of the sign-in experience within the browser.
+
+```swift
+let auth = WebAuthentication(issuer: issuer,
+                             clientId: clientId,
+                             scopes: "openid profile offline_access",
+                             redirectUri: redirectUri)
+let token = try await auth.signIn(from: view.window,
+                                  options: [
+                                      .login(hint: "user@example.com"),
+                                      .prompt(.login),
+                                  ])
+```
+
 ## Query String Parameters
 
-The simplest approach to customizing your authorization URL is adding additional parameters to the query string. These values can be supplied to the initializer, either through the ``WebAuthentication/init(issuer:clientId:scopes:redirectUri:logoutRedirectUri:additionalParameters:)`` initializer, or through the `Okta.plist` configuration format (see <doc:ConfiguringYourClient> for more information).
+Another approach to customizing your authorization URL is through adding additional parameters to the query string. These values can be supplied to the initializer through the ``WebAuthentication/init(issuer:clientId:scopes:redirectUri:logoutRedirectUri:additionalParameters:)`` initializer or through the `Okta.plist` configuration format (see <doc:ConfiguringYourClient> for more information), or by when invoking the ``WebAuthentication/signIn(from:options:)`` or ``WebAuthentication/signOut(from:credential:options:)`` functions.
+
+When passing values to the initializer, you can supply raw string key/value pairs.
 
 ```swift
 let auth = WebAuthentication(issuer: issuer,

--- a/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/Extensions/WebAuthentication.md
+++ b/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/Extensions/WebAuthentication.md
@@ -17,22 +17,22 @@
 
 ### Sign In
 
-- ``signIn(from:)``
-- ``signIn(from:completion:)``
+- ``signIn(from:options:)``
+- ``signIn(from:options:completion:)``
 
 ### Sign Out Using Credential
 
 - <doc:HowToSignOut>
-- ``signOut(from:credential:)``
-- ``signOut(from:credential:completion:)``
+- ``signOut(from:credential:options:)``
+- ``signOut(from:credential:options:completion:)``
 
 ### Sign Out Using Token
 
 - <doc:HowToSignOut>
-- ``signOut(from:token:)-2cj8w``
-- ``signOut(from:token:)-6qrgc``
-- ``signOut(from:token:completion:)-8o8xk``
-- ``signOut(from:token:completion:)-4ae85``
+- ``signOut(from:token:options:)-4x9ic``
+- ``signOut(from:token:options:)-33i36``
+- ``signOut(from:token:options:completion:)-3q66k``
+- ``signOut(from:token:options:completion:)-2jka2``
 
 ### Sign In Using App Link
 
@@ -53,6 +53,6 @@
 
 Signing in and -out is intended to be simple using this class, with several options for configuring your client (see <doc:ConfiguringYourClient> for more information). Once your client is configured, it is available through a shared singleton property ``shared``, or can be directly accessed if you create an instance directly.
 
-The ``signIn(from:)`` function (or ``signIn(from:completion:)`` for applications not using Swift Concurrency) presents a browser from the window supplied to the `from` argument, which the user can use to enter their account information.  After the sign in completes, the result is returned allowing your application to continue.
+The ``signIn(from:options:)`` function (or ``signIn(from:options:completion:)`` for applications not using Swift Concurrency) presents a browser from the window supplied to the `from` argument, which the user can use to enter their account information.  After the sign in completes, the result is returned allowing your application to continue.
 
-When signing a user out, the ``signOut(from:credential:)`` function similarly presents a browser to the user, in order to clear cookies and other browser state that is associated with the user's session.
+When signing a user out, the ``signOut(from:credential:options:)`` function similarly presents a browser to the user, in order to clear cookies and other browser state that is associated with the user's session.

--- a/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
@@ -121,6 +121,32 @@ final class SessionLogoutFlowSuccessTests: XCTestCase {
         XCTAssertNil(flow.context)
         XCTAssertFalse(flow.inProgress)
     }
+
+    func testPromptWithBlocks() throws {
+        XCTAssertNil(flow.context)
+        XCTAssertFalse(flow.inProgress)
+        
+        let context = SessionLogoutFlow.Context(idToken: logoutIDToken, state: state)
+        let resumeExpection = expectation(description: "Expect success")
+        
+        try flow.start(with: context, additionalParameters: ["prompt": "login"]) { result in
+            switch result {
+            case .success(let url):
+                XCTAssertEqual(url.absoluteString, """
+                               https://example.okta.com/oauth2/v1/logout\
+                               ?id_token_hint=\(self.logoutIDToken)\
+                               &prompt=login\
+                               &state=\(self.state)
+                               """)
+            case .failure:
+                XCTFail()
+            }
+
+            resumeExpection.fulfill()
+        }
+        
+        wait(for: [resumeExpection], timeout: 1)
+    }
     
     #if swift(>=5.5.1)
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)

--- a/Tests/WebAuthenticationUITests/AuthenticationServicesProviderTests.swift
+++ b/Tests/WebAuthenticationUITests/AuthenticationServicesProviderTests.swift
@@ -82,7 +82,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     }
     
     func testSuccessfulAuthentication() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
         
         XCTAssertNotNil(provider.authenticationSession)
@@ -99,7 +99,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     }
 
     func testErrorResponse() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -114,7 +114,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     }
 
     func testUserCancelled() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -131,7 +131,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     }
 
     func testNoResponse() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -147,7 +147,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     func testLogout() throws {
         MockAuthenticationServicesProviderSession.redirectUri = URL(string: "com.example:/logout?foo=bar")
     
-        provider.logout(context: .init(idToken: "idToken", state: "state"))
+        provider.logout(context: .init(idToken: "idToken", state: "state"), additionalParameters: nil)
         try waitFor(.logoutUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -161,7 +161,7 @@ class AuthenticationServicesProviderTests: ProviderTestBase {
     func testLogoutError() throws {
         MockAuthenticationServicesProviderSession.redirectError = WebAuthenticationError.userCancelledLogin
 
-        provider.logout(context: .init(idToken: "idToken", state: "state"))
+        provider.logout(context: .init(idToken: "idToken", state: "state"), additionalParameters: nil)
         try waitFor(.logoutUrl)
         
         XCTAssertNotNil(provider.authenticationSession)

--- a/Tests/WebAuthenticationUITests/OptionsTests.swift
+++ b/Tests/WebAuthenticationUITests/OptionsTests.swift
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+
+import XCTest
+@testable import TestCommon
+@testable import WebAuthenticationUI
+
+class OptionsTests: XCTestCase {
+    func testOptionProperties() throws {
+        let options: [WebAuthentication.Option] = [
+            .login(hint: "foo"),
+            .display("mobile"),
+            .idpScope("foo bar"),
+            .idp(url: URL(string: "https://example.com/idp")!),
+            .prompt(.none),
+            .maxAge(500),
+            .state("ABC123"),
+            .custom(key: "name", value: "value")
+        ]
+        
+        XCTAssertEqual(options.additionalParameters, [
+            "login_hint": "foo",
+            "display": "mobile",
+            "idp_scope": "foo bar",
+            "idp": "https://example.com/idp",
+            "prompt": "none",
+            "name": "value"
+        ])
+        
+        XCTAssertEqual(options.maxAge, 500)
+        XCTAssertEqual(options.state, "ABC123")
+        
+        let context = try XCTUnwrap(options.context)
+        XCTAssertEqual(context.state, "ABC123")
+        XCTAssertEqual(context.maxAge, 500)
+    }
+    
+    func testMissingOptions() throws {
+        let options: [WebAuthentication.Option] = []
+
+        XCTAssertNil(options.maxAge)
+        XCTAssertNil(options.state)
+        XCTAssertNil(options.context)
+    }
+    
+    func testPrompts() throws {
+        XCTAssertEqual(WebAuthentication.Option.Prompt.none.rawValue, "none")
+        XCTAssertEqual(WebAuthentication.Option.Prompt.login.rawValue, "login")
+        XCTAssertEqual(WebAuthentication.Option.Prompt.consent.rawValue, "consent")
+        XCTAssertEqual(WebAuthentication.Option.Prompt.loginAndConsent.rawValue, "login consent")
+    }
+}
+
+#endif

--- a/Tests/WebAuthenticationUITests/SafariBrowserProviderTests.swift
+++ b/Tests/WebAuthenticationUITests/SafariBrowserProviderTests.swift
@@ -28,7 +28,7 @@ class SafariBrowserProviderTests: ProviderTestBase {
     }
     
     func testControllerCreation() throws {
-        provider.start(context: nil)
+        provider.start(context: nil, additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         // Wait for the controller to dismiss / deallocate

--- a/Tests/WebAuthenticationUITests/SafariServicesProviderTests.swift
+++ b/Tests/WebAuthenticationUITests/SafariServicesProviderTests.swift
@@ -30,7 +30,7 @@ class SafariServicesProviderTests: ProviderTestBase {
     }
     
     func testSuccessfulAuthentication() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -44,7 +44,7 @@ class SafariServicesProviderTests: ProviderTestBase {
     }
 
     func testErrorResponse() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -56,7 +56,7 @@ class SafariServicesProviderTests: ProviderTestBase {
     }
 
     func testUserCancelled() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -68,7 +68,7 @@ class SafariServicesProviderTests: ProviderTestBase {
     }
 
     func testNoResponse() throws {
-        provider.start(context: .init(state: "state"))
+        provider.start(context: .init(state: "state"), additionalParameters: nil)
         try waitFor(.authenticateUrl)
 
         XCTAssertNotNil(provider.authenticationSession)
@@ -79,7 +79,7 @@ class SafariServicesProviderTests: ProviderTestBase {
     }
     
     func testLogout() throws {
-        provider.logout(context: .init(idToken: "idToken", state: "state"))
+        provider.logout(context: .init(idToken: "idToken", state: "state"), additionalParameters: nil)
         try waitFor(.logoutUrl)
 
         XCTAssertNotNil(provider.authenticationSession)

--- a/Tests/WebAuthenticationUITests/WebAuthenticationFlowTests.swift
+++ b/Tests/WebAuthenticationUITests/WebAuthenticationFlowTests.swift
@@ -42,9 +42,9 @@ class WebAuthenticationUITests: XCTestCase {
     }
     
     func testStart() throws {
-        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow, context: .init(state: "qwe"))
+        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow)
         
-        webAuth.signIn(from: nil) { result in }
+        webAuth.signIn(from: nil, options: [.state("qwe")]) { result in }
         
         let webAuthProvider = try XCTUnwrap(webAuth.provider as? WebAuthenticationProviderMock)
 
@@ -53,9 +53,9 @@ class WebAuthenticationUITests: XCTestCase {
     }
     
     func testLogout() throws {
-        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow, context: .init(state: "qwe"))
+        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow)
         
-        webAuth.signOut(from: nil, token: "idToken") { result in }
+        webAuth.signOut(from: nil, token: "idToken", options: [.state("qwe")]) { result in }
         
         let provider = try XCTUnwrap(webAuth.provider as? WebAuthenticationProviderMock)
         XCTAssertNil(webAuth.completionBlock)
@@ -64,11 +64,11 @@ class WebAuthenticationUITests: XCTestCase {
     }
     
     func testCancel() throws {
-        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow, context: .init(state: "qwe"))
+        let webAuth = WebAuthenticationMock(loginFlow: loginFlow, logoutFlow: logoutFlow)
         
         XCTAssertNil(webAuth.provider)
         
-        webAuth.signIn(from: nil) { result in }
+        webAuth.signIn(from: nil, options: [.state("qwe")]) { result in }
 
         let webAuthProvider = try XCTUnwrap(webAuth.provider as? WebAuthenticationProviderMock)
 

--- a/Tests/WebAuthenticationUITests/WebAuthenticationInitializerTests.swift
+++ b/Tests/WebAuthenticationUITests/WebAuthenticationInitializerTests.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+#if canImport(UIKit) || canImport(AppKit)
+
+import XCTest
+@testable import AuthFoundation
+@testable import TestCommon
+@testable import OktaOAuth2
+@testable import WebAuthenticationUI
+
+class WebAuthenticationInitializerTests: XCTestCase {
+    private let issuer = URL(string: "https://example.com")!
+    private let redirectUri = URL(string: "com.example:/callback")!
+    private let logoutRedirectUri = URL(string: "com.example:/logout")!
+    
+    func testInitializer() throws {
+        let auth = WebAuthentication(issuer: issuer,
+                                     clientId: "client_id",
+                                     scopes: "openid profile",
+                                     redirectUri: redirectUri,
+                                     logoutRedirectUri: logoutRedirectUri,
+                                     additionalParameters: ["foo": "bar"])
+        XCTAssertEqual(auth.signInFlow.client.configuration.clientId, "client_id")
+        XCTAssertEqual(auth.signInFlow.client.configuration.scopes, "openid profile")
+        XCTAssertTrue(auth.signInFlow.client === auth.signOutFlow?.client)
+        XCTAssertEqual(auth.signInFlow.additionalParameters, ["foo": "bar"])
+        XCTAssertEqual(auth.signOutFlow?.additionalParameters, ["foo": "bar"])
+    }
+}
+
+#endif

--- a/Tests/WebAuthenticationUITests/WebAuthenticationMocks.swift
+++ b/Tests/WebAuthenticationUITests/WebAuthenticationMocks.swift
@@ -44,18 +44,18 @@ class WebAuthenticationProviderMock: WebAuthenticationProvider {
         self.delegate = delegate
     }
     
-    func start(context: AuthorizationCodeFlow.Context?) {
+    func start(context: AuthorizationCodeFlow.Context?, additionalParameters: [String: String]?) {
         state = .started
         
-        loginFlow.start(with: nil) { result in
+        loginFlow.start(with: nil, additionalParameters: additionalParameters) { result in
             
         }
     }
     
-    func logout(context: SessionLogoutFlow.Context) {
+    func logout(context: SessionLogoutFlow.Context, additionalParameters: [String: String]?) {
         state = .started
         
-        try? logoutFlow?.start(idToken: "idToken") { result in
+        try? logoutFlow?.start(idToken: "idToken", additionalParameters: additionalParameters) { result in
             
         }
     }


### PR DESCRIPTION
Common workflows within OIDC Redirect authentication for native applications involve different entry-points for “Sign In”, “Register”, skipping “remember me” states, etc. These are controlled through the use of extra parameters to the initial authorize call, which are passed to the sign-in widget. In many cases, the only difference between these authentication modes is the extra parameters (prompt, idp, etc). However, in the current SDK, there is no way to conveniently supply those extra arguments without creating a brand new instance of the authentication client.

This PR adds the ability to include extra arguments to the signIn/signOut WebAuthentication functions, without the need to create an entirely separate client, when all other OIDC/OAuth2 parameters remain the same.

For example:

```swift
let client = try WebAuthentication() // Use the default config
let token = try client.signIn(from: view.window, options: [.prompt(.login)])

// Or
let token = try client.start([with](from: view.window, options): [.idp(url), .custom("key", "value")])
```

Furthermore, there are some instances where the current API accepts values, such as state and nonce at init time, which is counter to the way the API works. These values should be supplied when the flow is started.