### PR TITLE
Introduce OAuth2 client authentication, with support for optionally supplying a Client Secret

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,10 @@ whitelist_rules:
   - class_delegate_protocol
   - cyclomatic_complexity
 
+disabled_rules:
+  - line_length
+  - nesting
+
 # Override rule to return as warning/error
 closing_brace:
   severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -47,6 +47,8 @@ whitelist_rules:
 disabled_rules:
   - line_length
   - nesting
+  - opening_brace
+  - statement_position
 
 # Override rule to return as warning/error
 closing_brace:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,10 @@
-whitelist_rules:
+only_rules:
   # Spacing
   - closing_brace
   - closure_spacing
   - comma
   - colon
-
+ 
   # Whitespace (Xcode configuration)
   - leading_whitespace
   #- let_var_whitespace # Disabled due to https://github.com/realm/SwiftLint/issues/2980
@@ -12,43 +12,37 @@ whitelist_rules:
   - operator_usage_whitespace
   - return_arrow_whitespace
   - trailing_whitespace
-
+ 
   # Empty
   - empty_collection_literal
   - empty_count
   - empty_string
-
+ 
   # Force
   - force_cast
   - force_try
   - force_unwrapping
-
+ 
   # Closures
   - closure_body_length
   - closure_end_indentation
   - closure_parameter_position
-
+ 
   # Style
   # - attributes - disabled due to rule issue. See: https://github.com/okta/okta-devices-swift/pull/93
   - collection_alignment
   - control_statement
   - file_header
-
+ 
   # Order
   #- file_types_order - disabled due to the impracticality of private/fileprivate usages
   - modifier_order
   - protocol_property_accessors_order
-
+ 
   # Lint
   - anyobject_protocol
   - class_delegate_protocol
   - cyclomatic_complexity
-
-disabled_rules:
-  - line_length
-  - nesting
-  - opening_brace
-  - statement_position
 
 # Override rule to return as warning/error
 closing_brace:
@@ -61,8 +55,6 @@ colon:
   severity: error
 
 leading_whitespace:
-  severity: error
-let_var_whitespace:
   severity: error
 operator_whitespace:
   severity: error

--- a/OktaDirectAuth.podspec
+++ b/OktaDirectAuth.podspec
@@ -1,10 +1,9 @@
 Pod::Spec.new do |s|
-    s.name             = "OktaAuthFoundation"
-    s.module_name      = "AuthFoundation"
+    s.name             = "OktaDirectAuth"
     s.version          = "1.4.0"
-    s.summary          = "Okta Authentication Foundation"
+    s.summary          = "Okta Direct Authentication"
     s.description      = <<-DESC
-Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.
+Enables application developers to build native sign in experiences using the Okta Direct Authentication API.
                          DESC
     s.platforms = {
         :ios     => "9.0",
@@ -21,7 +20,9 @@ Provides the foundation and common features used to authenticate users, managing
     s.license       = { :type => "APACHE2", :file => "LICENSE" }
     s.authors       = { "Okta Developers" => "developer@okta.com"}
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
-    s.source_files  = "Sources/AuthFoundation/**/*.swift"
-    s.resources     = "Sources/AuthFoundation/Resources/*.lproj"
+    s.source_files  = "Sources/OktaDirectAuth/**/*.swift"
+    s.resources     = "Sources/OktaDirectAuth/Resources/*.lproj"
     s.swift_version = "5.5"
+
+    s.dependency "OktaAuthFoundation", "#{s.version.to_s}"
 end

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.3.1"
+    s.version          = "1.4.0"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.3.1"
+    s.version          = "1.4.0"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.3.1   | ✔️ Stable                             |
+| 1.4.0   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Samples/ClassicNativeAuth/ClassicNativeAuth (iOS)/AppDelegate.swift
+++ b/Samples/ClassicNativeAuth/ClassicNativeAuth (iOS)/AppDelegate.swift
@@ -51,4 +51,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/Samples/ClassicNativeAuth/ClassicNativeAuth (iOS)/SceneDelegate.swift
+++ b/Samples/ClassicNativeAuth/ClassicNativeAuth (iOS)/SceneDelegate.swift
@@ -45,7 +45,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         windowScene = scene
         
-        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { _ in
             self.setRootViewController()
         }
         
@@ -76,4 +76,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidEnterBackground(_ scene: UIScene) {
     }
 }
-

--- a/Samples/DeviceAuthSignIn/DeviceAuthSignIn (iOS)/SceneDelegate.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignIn (iOS)/SceneDelegate.swift
@@ -46,7 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         windowScene = scene
         
-        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { _ in
             self.setRootViewController()
         }
         

--- a/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/AppDelegate.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             try? Keychain.Search().delete()
         }
         
-        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { _ in
             self.setRootViewController()
         }
         
@@ -77,4 +77,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 }
-

--- a/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/ViewController.swift
+++ b/Samples/DeviceAuthSignIn/DeviceAuthSignIn (tvOS)/DeviceAuthSignIn/ViewController.swift
@@ -62,7 +62,7 @@ class ViewController: UIViewController {
             return
         }
 
-        flow.start() { result in
+        flow.start { result in
             DispatchQueue.main.async {
                 switch result {
                 case .failure(let error):
@@ -133,7 +133,7 @@ class ViewController: UIViewController {
             return
         }
         
-        var image: UIImage? = nil
+        var image: UIImage?
         defer {
             codeImageView.image = image
         }
@@ -166,4 +166,3 @@ class ViewController: UIViewController {
         ])
     }
 }
-

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/AppDelegate.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/AppDelegate.swift
@@ -55,4 +55,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return extensionPointIdentifier != .keyboard
     }
 }
-

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SceneDelegate.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SceneDelegate.swift
@@ -45,7 +45,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         windowScene = scene
         
-        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { _ in
             self.setRootViewController()
         }
         

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInView.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInView.swift
@@ -82,6 +82,7 @@ struct SignInView: View {
     }
 }
 
+// swiftlint:disable force_unwrapping
 struct SignInViewPrimary_Previews: PreviewProvider {
     static var previews: some View {
         SignInView(flow: .init(issuer: URL(string: "https://example.com")!,
@@ -99,3 +100,4 @@ struct SignInViewSecondary_Previews: PreviewProvider {
                                               mfaToken: "abcd1234")))
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInView.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInView.swift
@@ -82,7 +82,7 @@ struct SignInView: View {
     }
 }
 
-struct SignInView_Primary_Previews: PreviewProvider {
+struct SignInViewPrimary_Previews: PreviewProvider {
     static var previews: some View {
         SignInView(flow: .init(issuer: URL(string: "https://example.com")!,
                                clientId: "abcd123",
@@ -90,7 +90,7 @@ struct SignInView_Primary_Previews: PreviewProvider {
     }
 }
 
-struct SignInView_Secondary_Previews: PreviewProvider {
+struct SignInViewSecondary_Previews: PreviewProvider {
     static var previews: some View {
         SignInView(flow: .init(issuer: URL(string: "https://example.com")!,
                                clientId: "abcd123",

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
@@ -36,4 +36,3 @@ class SignInViewController: UIHostingController<SignInView> {
         super.init(coder: aDecoder, rootView: SignInView(flow: flow))
     }
 }
-

--- a/Samples/OIDCMigration/OIDCMigration/OIDCSignInViewController.swift
+++ b/Samples/OIDCMigration/OIDCMigration/OIDCSignInViewController.swift
@@ -113,7 +113,7 @@ class OIDCSignInViewController: UIViewController {
             return
         }
 
-        oktaOidc?.signOutOfOkta(stateManager, from: self, callback: { error in
+        oktaOidc?.signOutOfOkta(stateManager, from: self, callback: { _ in
             try? stateManager.removeFromSecureStorage()
             self.updateUIState()
         })

--- a/Samples/OIDCMigration/OIDCMigration/SceneDelegate.swift
+++ b/Samples/OIDCMigration/OIDCMigration/SceneDelegate.swift
@@ -16,7 +16,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -52,6 +51,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
 }
-

--- a/Samples/Shared/Common/Testing/XCTest+Extensions.swift
+++ b/Samples/Shared/Common/Testing/XCTest+Extensions.swift
@@ -87,7 +87,7 @@ extension XCUIElementQuery: Sequence {
             guard index < self.count else { return nil }
 
             let element = self.element(boundBy: Int(index))
-            index = index + 1
+            index += 1
             return element
         }
     }

--- a/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/ProfileTableViewController.swift
@@ -49,7 +49,7 @@ class ProfileTableViewController: UITableViewController {
             credential?.automaticRefresh = true
             credential?.refreshIfNeeded { result in
                 switch result {
-                case .success():
+                case .success:
                     self.credential?.userInfo { result in
                         guard case let .success(userInfo) = result else { return }
                         DispatchQueue.main.async {
@@ -120,7 +120,7 @@ class ProfileTableViewController: UITableViewController {
                 .init(kind: .rightDetail, id: "userId", title: "User ID", detail: user.subject),
                 .init(kind: .rightDetail, id: "createdAt", title: "Created at", detail: updatedAt),
                 .init(kind: .rightDetail, id: "isDefaultCredential", title: "Is Default", detail: defaultValue),
-                .init(kind: .disclosure, id: "details", title: "Token details"),
+                .init(kind: .disclosure, id: "details", title: "Token details")
             ]
         }
         

--- a/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/AppDelegate.swift
+++ b/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/AppDelegate.swift
@@ -48,4 +48,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 }
-

--- a/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/SceneDelegate.swift
+++ b/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/SceneDelegate.swift
@@ -64,5 +64,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 }
-
-

--- a/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/SingleSignOnViewController.swift
+++ b/Samples/WebSignIn/SingleSignOn (iOS)/SingleSignOn/SingleSignOnViewController.swift
@@ -116,4 +116,3 @@ final class SingleSignOnViewController: UIViewController {
         indicatorView.isHidden = true
     }
 }
-

--- a/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/AppDelegate.swift
+++ b/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/AppDelegate.swift
@@ -61,4 +61,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SceneDelegate.swift
+++ b/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SceneDelegate.swift
@@ -46,7 +46,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene) else { return }
         windowScene = scene
         
-        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .defaultCredentialChanged, object: nil, queue: .main) { _ in
             self.setRootViewController()
         }
         

--- a/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SignInViewController.swift
+++ b/Samples/WebSignIn/WebSignIn (iOS)/WebSignIn/SignInViewController.swift
@@ -97,12 +97,12 @@ class SignInViewController: UIViewController {
         let alert = UIAlertController(title: "Sign In with Refresh Token",
                                       message: "Enter the refresh token below",
                                       preferredStyle: .alert)
-        alert.addTextField() { field in
+        alert.addTextField { field in
             field.placeholder = "refresh_token"
             field.autocorrectionType = .no
         }
         alert.addAction(.init(title: "Cancel", style: .cancel))
-        alert.addAction(.init(title: "OK", style: .default) { action in
+        alert.addAction(.init(title: "OK", style: .default) { _ in
             guard let textField = alert.textFields?.first,
                 let string = textField.text,
                 !string.isEmpty

--- a/Samples/WebSignIn/WebSignIn (macOS)/WebSignIn/SignIn/SignInView.swift
+++ b/Samples/WebSignIn/WebSignIn (macOS)/WebSignIn/SignIn/SignInView.swift
@@ -81,5 +81,3 @@ struct ContentView_Previews: PreviewProvider {
     }
 }
 #endif
-
-

--- a/Sources/AuthFoundation/JWT/Extensions/Claim+Extensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/Claim+Extensions.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 
+// swiftlint:disable function_body_length
 // swiftlint:disable cyclomatic_complexity
 extension Claim: RawRepresentable, Equatable {
     public typealias RawValue = String
@@ -323,3 +324,4 @@ extension Claim: RawRepresentable, Equatable {
     }
 }
 // swiftlint:enable cyclomatic_complexity
+// swiftlint:enable function_body_length

--- a/Sources/AuthFoundation/JWT/Internal/Data+SigningExtensions.swift
+++ b/Sources/AuthFoundation/JWT/Internal/Data+SigningExtensions.swift
@@ -20,11 +20,11 @@ private extension Int {
         }
         
         // Long form
-        let i = (self / 256) + 1
+        let index = (self / 256) + 1
         var len = self
-        var result: [CUnsignedChar] = [CUnsignedChar(i + 0x80)]
+        var result: [CUnsignedChar] = [CUnsignedChar(index + 0x80)]
         
-        for _ in 0..<i {
+        for _ in 0..<index {
             result.insert(CUnsignedChar(len & 0xFF), at: 1)
             len = len >> 8
         }

--- a/Sources/AuthFoundation/JWT/Internal/Data+SigningExtensions.swift
+++ b/Sources/AuthFoundation/JWT/Internal/Data+SigningExtensions.swift
@@ -16,7 +16,7 @@ private extension Int {
     func encodedOctets() -> [CUnsignedChar] {
         // Short form
         if self < 128 {
-            return [CUnsignedChar(self)];
+            return [CUnsignedChar(self)]
         }
         
         // Long form

--- a/Sources/AuthFoundation/JWT/Internal/JWK+Extensions.swift
+++ b/Sources/AuthFoundation/JWT/Internal/JWK+Extensions.swift
@@ -132,7 +132,7 @@ extension JWK {
                 kSecAttrKeyType: kSecAttrKeyTypeRSA,
                 kSecAttrKeyClass: kSecAttrKeyTypeRSA,
                 kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
-                kSecReturnRef: true,
+                kSecReturnRef: true
             ]
             
             var keyRef: AnyObject?

--- a/Sources/AuthFoundation/JWT/JWK+Enums.swift
+++ b/Sources/AuthFoundation/JWT/JWK+Enums.swift
@@ -26,6 +26,7 @@ extension JWK {
         case encryption = "enc"
     }
     
+    // swiftlint:disable identifier_name
     /// The algorithm this key is intended to be used with.
     public enum Algorithm: String, Codable {
         // JWS Algorithms according to https://www.rfc-editor.org/rfc/rfc7518.html#section-3.1
@@ -62,4 +63,5 @@ extension JWK {
         case pbes2_HS384_A192KW = "PBES2-HS384+A192KW"
         case pbes2_HS512_A256KW = "PBES2-HS512+A256KW"
     }
+    // swiftlint:enable identifier_name
 }

--- a/Sources/AuthFoundation/JWT/JWKS.swift
+++ b/Sources/AuthFoundation/JWT/JWKS.swift
@@ -37,8 +37,8 @@ public struct JWKS: Codable, Equatable, Collection {
         keys[index]
     }
     
-    public func index(after i: Index) -> Index {
-        keys.index(after: i)
+    public func index(after index: Index) -> Index {
+        keys.index(after: index)
     }
 
     public static func == (lhs: JWKS, rhs: JWKS) -> Bool {

--- a/Sources/AuthFoundation/JWT/JWTError.swift
+++ b/Sources/AuthFoundation/JWT/JWTError.swift
@@ -102,7 +102,7 @@ extension JWTError: LocalizedError {
                                      bundle: .authFoundation,
                                      comment: "")
 
-        case .cannotCreateKey(code: _, description: _):
+        case .cannotCreateKey:
             return NSLocalizedString("jwt_cannot_create_key",
                                      tableName: "AuthFoundation",
                                      bundle: .authFoundation,

--- a/Sources/AuthFoundation/Migration/Migrators/OIDCLegacyMigrator.swift
+++ b/Sources/AuthFoundation/Migration/Migrators/OIDCLegacyMigrator.swift
@@ -14,7 +14,7 @@ import Foundation
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 
-fileprivate let accountIdRegex = try? NSRegularExpression(pattern: "0oa[0-9a-zA-Z]{17}")
+private let accountIdRegex = try? NSRegularExpression(pattern: "0oa[0-9a-zA-Z]{17}")
 
 extension SDKVersion.Migration {
     /// Migrator capable of importing credentials from the legacy `OktaOidc` SDK.
@@ -243,7 +243,7 @@ extension SDKVersion.Migration {
                 @objc let idToken: String?
                 @objc let refreshToken: String?
                 @objc let scope: String?
-                @objc let additionalParameters: Dictionary<String, String>?
+                @objc let additionalParameters: [String: String]?
 
                 func encode(with coder: NSCoder) {}
 
@@ -254,7 +254,7 @@ extension SDKVersion.Migration {
                     tokenType = coder.decodeObject(forKey: "token_type") as? String
                     idToken = coder.decodeObject(forKey: "id_token") as? String
                     scope = coder.decodeObject(forKey: "scope") as? String
-                    additionalParameters = coder.decodeObject(forKey: "additionalParameters") as? Dictionary<String, String>
+                    additionalParameters = coder.decodeObject(forKey: "additionalParameters") as? [String: String]
                 }
             }
             

--- a/Sources/AuthFoundation/Network/APIClient.swift
+++ b/Sources/AuthFoundation/Network/APIClient.swift
@@ -277,7 +277,7 @@ extension APIClient {
 extension APIClient {
     private func relatedLinks<T>(from linkHeader: String?) -> [APIResponse<T>.Link: URL] {
         guard let linkHeader = linkHeader,
-              let matches = linkRegex?.matches(in: linkHeader, options: [], range: NSMakeRange(0, linkHeader.count))
+              let matches = linkRegex?.matches(in: linkHeader, options: [], range: NSRange(location: 0, length: linkHeader.count))
         else {
             return [:]
         }
@@ -299,12 +299,12 @@ extension APIClient {
     }
     
     private func validate<T>(data: Data, response: HTTPURLResponse, rateInfo: APIRateLimit?, parsing context: APIParsingContext? = nil) throws -> APIResponse<T> {
-        var requestId: String? = nil
+        var requestId: String?
         if let requestIdHeader = requestIdHeader {
             requestId = response.allHeaderFields[requestIdHeader] as? String
         }
         
-        var date: Date? = nil
+        var date: Date?
         if let dateString = response.allHeaderFields["Date"] as? String {
             date = httpDateFormatter.date(from: dateString)
         }
@@ -324,7 +324,7 @@ extension APIClient {
     }
 }
 
-fileprivate let linkRegex = try? NSRegularExpression(pattern: "<([^>]+)>; rel=\"([^\"]+)\"", options: [])
+private let linkRegex = try? NSRegularExpression(pattern: "<([^>]+)>; rel=\"([^\"]+)\"", options: [])
 
 let httpDateFormatter: DateFormatter = {
     let dateFormatter = DateFormatter()

--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -289,4 +289,3 @@ extension APIContentType {
         }
     }
 }
-

--- a/Sources/AuthFoundation/OAuth2/ClientAuthentication.swift
+++ b/Sources/AuthFoundation/OAuth2/ClientAuthentication.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+extension OAuth2Client {
+    /// Defines the types of authentication the client may use when interacting with the authorization server.
+    public enum ClientAuthentication: Codable, Equatable, Hashable {
+        /// No client authentication will be made when interacting with the authorization server.
+        case none
+        
+        /// A client secret will be supplied when interacting with the authorization server.
+        case clientSecret(String)
+        
+        /// The additional parameters this authentication type will contribute to outgoing API requests when needed.
+        public var additionalParameters: [String: String]? {
+            switch self {
+            case .none:
+                return nil
+            case .clientSecret(let secret):
+                return ["client_secret": secret]
+            }
+        }
+    }
+}

--- a/Sources/AuthFoundation/OAuth2/Configuration.swift
+++ b/Sources/AuthFoundation/OAuth2/Configuration.swift
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+extension OAuth2Client {
+    /// The configuration for an ``OAuth2Client``.
+    ///
+    /// This defines the basic information necessary for interacting with an OAuth2 authorization server.
+    public final class Configuration: Codable, Equatable, Hashable, APIClientConfiguration {
+        /// The base URL for interactions with this OAuth2 server.
+        public let baseURL: URL
+        
+        /// The discovery URL used to retrieve the ``OpenIdConfiguration`` for this client.
+        public let discoveryURL: URL
+        
+        /// The unique client ID representing this ``OAuth2Client``.
+        public let clientId: String
+        
+        /// The list of OAuth2 scopes requested for this client.
+        public let scopes: String
+        
+        /// The type of authentication this client will perform when interacting with the authorization server.
+        public let authentication: ClientAuthentication
+        
+        /// Initializer for constructing an OAuth2Client.
+        /// - Parameters:
+        ///   - baseURL: Base URL.
+        ///   - discoveryURL: Discovery URL, or `nil` to accept the default OpenIDConfiguration endpoint.
+        ///   - clientId: The client ID.
+        ///   - scopes: The list of OAuth2 scopes.
+        ///   - authentication: The client authentication  model to use (Default: `.none`)
+        public init(baseURL: URL,
+                    discoveryURL: URL? = nil,
+                    clientId: String,
+                    scopes: String,
+                    authentication: ClientAuthentication = .none)
+        {
+            var relativeURL = baseURL
+            
+            // Ensure the base URL contains a trailing slash in its path, so request paths can be safely appended.
+            if !relativeURL.lastPathComponent.isEmpty {
+                relativeURL.appendPathComponent("")
+            }
+            
+            self.baseURL = baseURL
+            self.discoveryURL = discoveryURL ?? relativeURL.appendingPathComponent(".well-known/openid-configuration")
+            self.clientId = clientId
+            self.scopes = scopes
+            self.authentication = authentication
+        }
+        
+        /// Convenience initializer to create a client using a simple domain name.
+        /// - Parameters:
+        ///   - domain: Domain name for the OAuth2 client.
+        ///   - clientId: The client ID.
+        ///   - scopes: The list of OAuth2 scopes.
+        ///   - authentication: The client authentication  model to use (Default: `.none`)
+        public convenience init(domain: String,
+                                clientId: String,
+                                scopes: String,
+                                authentication: ClientAuthentication = .none) throws
+        {
+            guard let url = URL(string: "https://\(domain)") else {
+                throw OAuth2Error.invalidUrl
+            }
+            
+            self.init(baseURL: url, clientId: clientId, scopes: scopes, authentication: authentication)
+        }
+        
+        public static func == (lhs: OAuth2Client.Configuration, rhs: OAuth2Client.Configuration) -> Bool {
+            lhs.baseURL == rhs.baseURL &&
+            lhs.clientId == rhs.clientId &&
+            lhs.scopes == rhs.scopes &&
+            lhs.authentication == rhs.authentication
+        }
+        
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(baseURL)
+            hasher.combine(clientId)
+            hasher.combine(scopes)
+            hasher.combine(authentication)
+        }
+    }
+}

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -40,7 +40,7 @@ public final class OAuth2Client {
     public let configuration: Configuration
     
     /// Additional HTTP headers to include in outgoing network requests.
-    public var additionalHttpHeaders: [String: String]? = nil
+    public var additionalHttpHeaders: [String: String]?
     
     /// The OpenID configuration for this org.
     ///
@@ -272,7 +272,7 @@ public final class OAuth2Client {
                                                   configuration: clientSettings)
                 request.send(to: self) { result in
                     switch result {
-                    case .success(_):
+                    case .success:
                         completion(.success(()))
                     case .failure(let error):
                         completion(.failure(.network(error: error)))
@@ -547,7 +547,7 @@ extension OAuth2Client {
     /// - Returns: The OpenID configuration for the org identified by the client's base URL.
     public func openIdConfiguration() async throws -> OpenIdConfiguration {
         try await withCheckedThrowingContinuation { continuation in
-            openIdConfiguration() { result in
+            openIdConfiguration { result in
                 continuation.resume(with: result)
             }
         }
@@ -559,7 +559,7 @@ extension OAuth2Client {
     /// - Returns: The ``JWKS`` configuration for the org identified by the client's base URL.
     public func jwks() async throws -> JWKS {
         try await withCheckedThrowingContinuation { continuation in
-            jwks() { result in
+            jwks { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -30,106 +30,9 @@ extension OAuth2ClientDelegate {
     public func oauth(client: OAuth2Client, didRefresh token: Token, replacedWith newToken: Token?) {}
 }
 
+// swiftlint:disable type_body_length
 /// An OAuth2 client, used to interact with a given authorization server.
 public final class OAuth2Client {
-    /// The configuration for an ``OAuth2Client``.
-    ///
-    /// This defines the basic information necessary for interacting with an OAuth2 authorization server.
-    public final class Configuration: Codable, Equatable, Hashable, APIClientConfiguration {
-        /// The base URL for interactions with this OAuth2 server.
-        public let baseURL: URL
-        
-        /// The discovery URL used to retrieve the ``OpenIdConfiguration`` for this client.
-        public let discoveryURL: URL
-        
-        /// The unique client ID representing this ``OAuth2Client``.
-        public let clientId: String
-        
-        /// The list of OAuth2 scopes requested for this client.
-        public let scopes: String
-        
-        /// The type of authentication this client will perform when interacting with the authorization server.
-        public let authentication: ClientAuthentication
-                
-        /// Initializer for constructing an OAuth2Client.
-        /// - Parameters:
-        ///   - baseURL: Base URL.
-        ///   - discoveryURL: Discovery URL, or `nil` to accept the default OpenIDConfiguration endpoint.
-        ///   - clientId: The client ID.
-        ///   - scopes: The list of OAuth2 scopes.
-        ///   - authentication: The client authentication  model to use (Default: `.none`)
-        public init(baseURL: URL,
-                    discoveryURL: URL? = nil,
-                    clientId: String,
-                    scopes: String,
-                    authentication: ClientAuthentication = .none)
-        {
-            var relativeURL = baseURL
-
-            // Ensure the base URL contains a trailing slash in its path, so request paths can be safely appended.
-            if !relativeURL.lastPathComponent.isEmpty {
-                relativeURL.appendPathComponent("")
-            }
-            
-            self.baseURL = baseURL
-            self.discoveryURL = discoveryURL ?? relativeURL.appendingPathComponent(".well-known/openid-configuration")
-            self.clientId = clientId
-            self.scopes = scopes
-            self.authentication = authentication
-        }
-        
-        /// Convenience initializer to create a client using a simple domain name.
-        /// - Parameters:
-        ///   - domain: Domain name for the OAuth2 client.
-        ///   - clientId: The client ID.
-        ///   - scopes: The list of OAuth2 scopes.
-        ///   - authentication: The client authentication  model to use (Default: `.none`)
-        public convenience init(domain: String,
-                                clientId: String,
-                                scopes: String,
-                                authentication: ClientAuthentication = .none) throws
-        {
-            guard let url = URL(string: "https://\(domain)") else {
-                throw OAuth2Error.invalidUrl
-            }
-
-            self.init(baseURL: url, clientId: clientId, scopes: scopes, authentication: authentication)
-        }
-
-        public static func == (lhs: OAuth2Client.Configuration, rhs: OAuth2Client.Configuration) -> Bool {
-            lhs.baseURL == rhs.baseURL &&
-            lhs.clientId == rhs.clientId &&
-            lhs.scopes == rhs.scopes &&
-            lhs.authentication == rhs.authentication
-        }
-        
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(baseURL)
-            hasher.combine(clientId)
-            hasher.combine(scopes)
-            hasher.combine(authentication)
-        }
-    }
-
-    /// Defines the types of authentication the client may use when interacting with the authorization server.
-    public enum ClientAuthentication: Codable, Equatable, Hashable {
-        /// No client authentication will be made when interacting with the authorization server.
-        case none
-        
-        /// A client secret will be supplied when interacting with the authorization server.
-        case clientSecret(String)
-        
-        /// The additional parameters this authentication type will contribute to outgoing API requests when needed.
-        public var additionalParameters: [String: String]? {
-            switch self {
-            case .none:
-                return nil
-            case .clientSecret(let secret):
-                return ["client_secret": secret]
-            }
-        }
-    }
-
     /// The URLSession used by this client for network requests.
     public let session: URLSessionProtocol
     
@@ -310,7 +213,6 @@ public final class OAuth2Client {
                             NotificationCenter.default.post(name: .tokenRefreshed, object: newToken)
                             action.finish(.success(newToken))
                             
-
                         case .failure(let error):
                             self.delegateCollection.invoke { $0.oauth(client: self, didRefresh: token, replacedWith: nil) }
                             
@@ -634,6 +536,7 @@ public final class OAuth2Client {
     }()
     internal var jwksAction: CoalescedResult<Result<JWKS, OAuth2Error>>?
 }
+// swiftlint:enable type_body_length
 
 #if swift(>=5.5.1)
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)

--- a/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Error.swift
@@ -111,7 +111,7 @@ extension OAuth2Error: LocalizedError {
                                   comment: "Invalid URL"),
                 errorString)
 
-        case .cannotRevoke(type: _):
+        case .cannotRevoke:
             return NSLocalizedString("cannot_revoke_token",
                                      tableName: "AuthFoundation",
                                      bundle: .authFoundation,

--- a/Sources/AuthFoundation/Responses/GrantType.swift
+++ b/Sources/AuthFoundation/Responses/GrantType.swift
@@ -26,7 +26,7 @@ public enum GrantType: Codable, Hashable {
     case other(_ type: String)
 }
 
-fileprivate let Mapping: [String: GrantType] = [
+fileprivate let grantTypeMapping: [String: GrantType] = [
     "authorization_code": .authorizationCode,
     "implicit": .implicit,
     "refresh_token": .refreshToken,
@@ -44,7 +44,7 @@ extension GrantType: RawRepresentable {
     public typealias RawValue = String
     
     public init?(rawValue: String) {
-        if let mapping = Mapping[rawValue] {
+        if let mapping = grantTypeMapping[rawValue] {
             self = mapping
         } else {
             self = .other(rawValue)

--- a/Sources/AuthFoundation/Responses/GrantType.swift
+++ b/Sources/AuthFoundation/Responses/GrantType.swift
@@ -26,7 +26,7 @@ public enum GrantType: Codable, Hashable {
     case other(_ type: String)
 }
 
-fileprivate let grantTypeMapping: [String: GrantType] = [
+private let grantTypeMapping: [String: GrantType] = [
     "authorization_code": .authorizationCode,
     "implicit": .implicit,
     "refresh_token": .refreshToken,

--- a/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
+++ b/Sources/AuthFoundation/Responses/OAuth2ServerError.swift
@@ -52,7 +52,7 @@ extension OAuth2ServerError {
         case authorizationPending
         /// the authorization request is still pending and polling should continue
         case slowDown
-        //The "device_code" has expired, and the device authorization session has concluded.
+        /// The `device_code` has expired, and the device authorization session has concluded.
         case expiredToken
         /// The server denied the request.
         case accessDenied

--- a/Sources/AuthFoundation/Security/Internal/Keychain+Extensions.swift
+++ b/Sources/AuthFoundation/Security/Internal/Keychain+Extensions.swift
@@ -63,7 +63,7 @@ extension KeychainGettable {
             }
         }
         
-        guard let result = ref as? Dictionary<String, Any> else {
+        guard let result = ref as? [String: Any] else {
             throw KeychainError.invalidFormat
         }
         
@@ -92,7 +92,7 @@ extension KeychainListable {
             throw KeychainError.cannotList(code: status)
         }
         
-        guard let items = ref as? Array<Dictionary<String, Any>> else {
+        guard let items = ref as? [[String: Any]] else {
             throw KeychainError.invalidFormat
         }
 
@@ -102,7 +102,7 @@ extension KeychainListable {
 
 extension KeychainUpdatable {
     var updateQuery: [String: Any] {
-        query.filter { (key: String, value: Any) in
+        query.filter { (key: String, _: Any) in
             let keyAttr = key as CFString
             switch keyAttr {
             case kSecClass: fallthrough

--- a/Sources/AuthFoundation/Security/Keychain.swift
+++ b/Sources/AuthFoundation/Security/Keychain.swift
@@ -91,7 +91,7 @@ public struct Keychain {
                 throw KeychainError.cannotSave(code: status)
             }
             
-            guard let result = ref as? Dictionary<String, Any> else {
+            guard let result = ref as? [String: Any] else {
                 throw KeychainError.invalidFormat
             }
             

--- a/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
@@ -100,7 +100,7 @@ final class KeychainTokenStorage: TokenStorage {
                                          synchronizable: accessibility.isSynchronizable,
                                          value: try encoder.encode(metadata))
 
-        var context: KeychainAuthenticationContext? = nil
+        var context: KeychainAuthenticationContext?
         #if canImport(LocalAuthentication) && !os(tvOS)
         context = security.context
         #endif
@@ -143,7 +143,7 @@ final class KeychainTokenStorage: TokenStorage {
                                     generic: nil,
                                     value: data)
         
-        var context: KeychainAuthenticationContext? = nil
+        var context: KeychainAuthenticationContext?
         #if canImport(LocalAuthentication) && !os(tvOS)
         context = security?.context
         #endif

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -193,7 +193,7 @@ public final class Token: Codable, Equatable, Hashable, Expires {
             id = UUID().uuidString
         }
 
-        var idToken: JWT? = nil
+        var idToken: JWT?
         if let idTokenString = try container.decodeIfPresent(String.self, forKey: .idToken) {
             idToken = try JWT(idTokenString)
         }

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -41,7 +41,7 @@ extension Credential {
     /// Attempt to refresh the token.
     public func refresh() async throws {
         try await withCheckedThrowingContinuation { continuation in
-            refresh() { result in
+            refresh { result in
                 continuation.resume(with: result)
             }
         }
@@ -93,7 +93,7 @@ extension Credential {
     /// - Returns: The user info for this user.
     public func userInfo() async throws -> UserInfo {
         try await withCheckedThrowingContinuation { continuation in
-            userInfo() { result in
+            userInfo { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -231,7 +231,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
         oauth2.revoke(token, type: type) { result in
             defer { completion?(result) }
             
-            guard case .success(_) = result else { return }
+            guard case .success = result else { return }
             
             // Remove the credential from storage if the access token was revoked
             if shouldRemove {

--- a/Sources/AuthFoundation/User Management/Internal/DefaultCredentialDataSource.swift
+++ b/Sources/AuthFoundation/User Management/Internal/DefaultCredentialDataSource.swift
@@ -49,7 +49,7 @@ final class DefaultCredentialDataSource: CredentialDataSource {
     }
     
     func remove(credential: Credential) {
-        let _ = queue.sync(flags: .barrier) {
+        _ = queue.sync(flags: .barrier) {
             guard let index = credentials.firstIndex(of: credential) else { return }
             credentials.remove(at: index)
             delegate?.credential(dataSource: self, removed: credential)

--- a/Sources/AuthFoundation/Utilities/Bundle+AuthFoundation.swift
+++ b/Sources/AuthFoundation/Utilities/Bundle+AuthFoundation.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 #if !SWIFT_PACKAGE
-fileprivate let sharedLocalizationBundle: Bundle = {
+private let sharedLocalizationBundle: Bundle = {
     Bundle(for: Credential.self)
 }()
 #endif

--- a/Sources/AuthFoundation/Utilities/CoalescedResult.swift
+++ b/Sources/AuthFoundation/Utilities/CoalescedResult.swift
@@ -20,7 +20,7 @@ final class CoalescedResult<T> {
     }
     
     func start(_ operation: ((T) -> Void) -> Void) {
-        operation() { result in
+        operation { result in
             self.finish(result)
         }
     }

--- a/Sources/AuthFoundation/Utilities/JSONCoding.swift
+++ b/Sources/AuthFoundation/Utilities/JSONCoding.swift
@@ -28,12 +28,12 @@ struct JSONCodingKeys: CodingKey {
 }
 
 extension KeyedDecodingContainer {
-    func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any> {
+    func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> [String: Any] {
         let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
         return try container.decode(type)
     }
 
-    func decodeIfPresent(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any>? {
+    func decodeIfPresent(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> [String: Any]? {
         guard contains(key) else {
             return nil
         }
@@ -43,12 +43,12 @@ extension KeyedDecodingContainer {
         return try decode(type, forKey: key)
     }
 
-    func decode(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any> {
+    func decode(_ type: Array<Any>.Type, forKey key: K) throws -> [Any] {
         var container = try self.nestedUnkeyedContainer(forKey: key)
         return try container.decode(type)
     }
 
-    func decodeIfPresent(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any>? {
+    func decodeIfPresent(_ type: Array<Any>.Type, forKey key: K) throws -> [Any]? {
         guard contains(key) else {
             return nil
         }
@@ -58,8 +58,8 @@ extension KeyedDecodingContainer {
         return try decode(type, forKey: key)
     }
 
-    func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
-        var dictionary = Dictionary<String, Any>()
+    func decode(_ type: Dictionary<String, Any>.Type) throws -> [String: Any] {
+        var dictionary = [String: Any]()
 
         for key in allKeys {
             if let boolValue = try? decode(Bool.self, forKey: key) {
@@ -81,7 +81,7 @@ extension KeyedDecodingContainer {
 }
 
 extension UnkeyedDecodingContainer {
-    mutating func decode(_ type: Array<Any>.Type) throws -> Array<Any> {
+    mutating func decode(_ type: Array<Any>.Type) throws -> [Any] {
         var array: [Any] = []
         while isAtEnd == false {
             // See if the current value in the JSON array is `null` first and prevent infite recursion with nested arrays.
@@ -102,7 +102,7 @@ extension UnkeyedDecodingContainer {
         return array
     }
 
-    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
+    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> [String: Any] {
         let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
         return try nestedContainer.decode(type)
     }

--- a/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
+++ b/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
@@ -44,7 +44,10 @@ extension Date {
     }
 }
 
+// swiftlint:disable identifier_name
 fileprivate var SharedTimeCoordinator: TimeCoordinator = DefaultTimeCoordinator()
+// swiftlint:enable identifier_name
+
 class DefaultTimeCoordinator: TimeCoordinator, OAuth2ClientDelegate {
     static func resetToDefault() {
         Date.coordinator = DefaultTimeCoordinator()

--- a/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
+++ b/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
@@ -45,7 +45,7 @@ extension Date {
 }
 
 // swiftlint:disable identifier_name
-fileprivate var SharedTimeCoordinator: TimeCoordinator = DefaultTimeCoordinator()
+private var SharedTimeCoordinator: TimeCoordinator = DefaultTimeCoordinator()
 // swiftlint:enable identifier_name
 
 class DefaultTimeCoordinator: TimeCoordinator, OAuth2ClientDelegate {

--- a/Sources/AuthFoundation/Utilities/WeakCollection.swift
+++ b/Sources/AuthFoundation/Utilities/WeakCollection.swift
@@ -36,7 +36,7 @@ extension Weak: Equatable where Object: Equatable {}
 
 /// Property wrapper representing a collection of weak values.
 @propertyWrapper
-public struct WeakCollection<Collect, Element> where Collect: RangeReplaceableCollection, Collect.Element == Optional<Element>, Element: AnyObject {
+public struct WeakCollection<Collect, Element> where Collect: RangeReplaceableCollection, Collect.Element == Element?, Element: AnyObject {
     private var weakObjects = [Weak<Element>]()
 
     public init(wrappedValue value: Collect) { save(collection: value) }

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -12,4 +12,6 @@
 
 import Foundation
 
+// swiftlint:disable identifier_name
 public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.3.1")
+// swiftlint:enable identifier_name

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -13,5 +13,5 @@
 import Foundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.3.1")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.4.0")
 // swiftlint:enable identifier_name

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -251,7 +251,7 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
                     self.stepHandler?.process { result in
                         self.stepHandler = nil
                         if case let .success(status) = result,
-                            case .success(_) = status
+                            case .success = status
                         {
                             self.reset()
                         }

--- a/Sources/OktaDirectAuth/Internal/Authentication Factors/PrimaryFactor.swift
+++ b/Sources/OktaDirectAuth/Internal/Authentication Factors/PrimaryFactor.swift
@@ -31,15 +31,11 @@ extension DirectAuthenticationFlow.PrimaryFactor: AuthenticationFactor {
                      currentStatus: DirectAuthenticationFlow.Status? = nil,
                      factor: DirectAuthenticationFlow.PrimaryFactor) throws -> StepHandler
     {
-        let clientId = flow.client.configuration.clientId
-        let scope = flow.client.configuration.scopes
-
         switch self {
         case .otp(code: _): fallthrough
         case .password(_):
             let request = TokenRequest(openIdConfiguration: openIdConfiguration,
-                                       clientId: clientId,
-                                       scope: scope,
+                                       clientConfiguration: flow.client.configuration,
                                        loginHint: loginHint,
                                        factor: factor,
                                        grantTypesSupported: flow.supportedGrantTypes)

--- a/Sources/OktaDirectAuth/Internal/Authentication Factors/PrimaryFactor.swift
+++ b/Sources/OktaDirectAuth/Internal/Authentication Factors/PrimaryFactor.swift
@@ -16,7 +16,7 @@ import AuthFoundation
 extension DirectAuthenticationFlow.PrimaryFactor {
     var loginHintKey: String {
         switch self {
-        case .password(_):
+        case .password:
             return "username"
         default:
             return "login_hint"
@@ -32,8 +32,8 @@ extension DirectAuthenticationFlow.PrimaryFactor: AuthenticationFactor {
                      factor: DirectAuthenticationFlow.PrimaryFactor) throws -> StepHandler
     {
         switch self {
-        case .otp(code: _): fallthrough
-        case .password(_):
+        case .otp: fallthrough
+        case .password:
             let request = TokenRequest(openIdConfiguration: openIdConfiguration,
                                        clientConfiguration: flow.client.configuration,
                                        loginHint: loginHint,
@@ -62,7 +62,7 @@ extension DirectAuthenticationFlow.PrimaryFactor: AuthenticationFactor {
                 "grant_type": grantType.rawValue,
                 "password": password
             ]
-        case .oob(channel: _):
+        case .oob:
             return nil
         }
 
@@ -70,11 +70,11 @@ extension DirectAuthenticationFlow.PrimaryFactor: AuthenticationFactor {
 
     var grantType: GrantType {
         switch self {
-        case .otp(code: _):
+        case .otp:
             return .otp
-        case .password(_):
+        case .password:
             return .password
-        case .oob(channel: _):
+        case .oob:
             return .oob
         }
     }

--- a/Sources/OktaDirectAuth/Internal/Authentication Factors/SecondaryFactor.swift
+++ b/Sources/OktaDirectAuth/Internal/Authentication Factors/SecondaryFactor.swift
@@ -21,7 +21,7 @@ extension DirectAuthenticationFlow.SecondaryFactor: AuthenticationFactor {
                      factor: DirectAuthenticationFlow.SecondaryFactor) throws -> StepHandler
     {
         switch self {
-        case .otp(code: _):
+        case .otp:
             let request = TokenRequest(openIdConfiguration: openIdConfiguration,
                                        clientConfiguration: flow.client.configuration,
                                        loginHint: loginHint,
@@ -46,7 +46,7 @@ extension DirectAuthenticationFlow.SecondaryFactor: AuthenticationFactor {
                 "grant_type": grantType.rawValue,
                 "otp": code
             ]
-        case .oob(channel: _):
+        case .oob:
             return nil
         }
 
@@ -54,9 +54,9 @@ extension DirectAuthenticationFlow.SecondaryFactor: AuthenticationFactor {
 
     var grantType: GrantType {
         switch self {
-        case .otp(code: _):
+        case .otp:
             return .otpMFA
-        case .oob(channel: _):
+        case .oob:
             return .oobMFA
         }
     }

--- a/Sources/OktaDirectAuth/Internal/Authentication Factors/SecondaryFactor.swift
+++ b/Sources/OktaDirectAuth/Internal/Authentication Factors/SecondaryFactor.swift
@@ -20,14 +20,10 @@ extension DirectAuthenticationFlow.SecondaryFactor: AuthenticationFactor {
                      currentStatus: DirectAuthenticationFlow.Status?,
                      factor: DirectAuthenticationFlow.SecondaryFactor) throws -> StepHandler
     {
-        let clientId = flow.client.configuration.clientId
-        let scope = flow.client.configuration.scopes
-
         switch self {
         case .otp(code: _):
             let request = TokenRequest(openIdConfiguration: openIdConfiguration,
-                                       clientId: clientId,
-                                       scope: scope,
+                                       clientConfiguration: flow.client.configuration,
                                        loginHint: loginHint,
                                        factor: factor,
                                        mfaToken: currentStatus?.mfaToken,

--- a/Sources/OktaDirectAuth/Internal/Extensions/Bundle+OktaDirectAuth.swift
+++ b/Sources/OktaDirectAuth/Internal/Extensions/Bundle+OktaDirectAuth.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 #if !SWIFT_PACKAGE
-fileprivate let sharedLocalizationBundle: Bundle = {
+private let sharedLocalizationBundle: Bundle = {
     Bundle(for: DirectAuthenticationFlow.self)
 }()
 #endif

--- a/Sources/OktaDirectAuth/Internal/Requests/ChallengeRequest.swift
+++ b/Sources/OktaDirectAuth/Internal/Requests/ChallengeRequest.swift
@@ -21,12 +21,12 @@ extension OpenIdConfiguration {
 
 struct ChallengeRequest {
     let url: URL
-    let clientId: String
+    let clientConfiguration: OAuth2Client.Configuration
     let mfaToken: String
     let challengeTypesSupported: [GrantType]
     
     init(openIdConfiguration: OpenIdConfiguration,
-         clientId: String,
+         clientConfiguration: OAuth2Client.Configuration,
          mfaToken: String,
          challengeTypesSupported: [GrantType]) throws
     {
@@ -35,7 +35,7 @@ struct ChallengeRequest {
         }
         
         self.url = url
-        self.clientId = clientId
+        self.clientConfiguration = clientConfiguration
         self.mfaToken = mfaToken
         self.challengeTypesSupported = challengeTypesSupported
     }
@@ -74,12 +74,18 @@ extension ChallengeRequest: APIRequest, APIRequestBody {
     var contentType: APIContentType? { .formEncoded }
     var acceptsType: APIContentType? { .json }
     var bodyParameters: [String: Any]? {
-        [
-            "client_id": clientId,
+        var result: [String: Any] = [
+            "client_id": clientConfiguration.clientId,
             "mfa_token": mfaToken,
             "challenge_types_supported": challengeTypesSupported
                 .map(\.rawValue)
                 .joined(separator: " ")
         ]
+        
+        if let parameters = clientConfiguration.authentication.additionalParameters {
+            result.merge(parameters, uniquingKeysWith: { $1 })
+        }
+
+        return result
     }
 }

--- a/Sources/OktaDirectAuth/Internal/Requests/OOBAuthenticateRequest.swift
+++ b/Sources/OktaDirectAuth/Internal/Requests/OOBAuthenticateRequest.swift
@@ -11,6 +11,7 @@
 //
 
 import Foundation
+import AuthFoundation
 
 extension OpenIdConfiguration {
     var oobAuthenticateEndpoint: URL? {
@@ -28,12 +29,12 @@ struct OOBResponse: Codable {
 
 struct OOBAuthenticateRequest {
     let url: URL
-    let clientId: String
+    let clientConfiguration: OAuth2Client.Configuration
     let loginHint: String
     let channelHint: DirectAuthenticationFlow.OOBChannel
     
     init(openIdConfiguration: OpenIdConfiguration,
-         clientId: String,
+         clientConfiguration: OAuth2Client.Configuration,
          loginHint: String,
          channelHint: DirectAuthenticationFlow.OOBChannel) throws
     {
@@ -42,7 +43,7 @@ struct OOBAuthenticateRequest {
         }
         
         self.url = url
-        self.clientId = clientId
+        self.clientConfiguration = clientConfiguration
         self.loginHint = loginHint
         self.channelHint = channelHint
     }
@@ -59,10 +60,16 @@ extension OOBAuthenticateRequest: APIRequest, APIRequestBody {
     var contentType: APIContentType? { .formEncoded }
     var acceptsType: APIContentType? { .json }
     var bodyParameters: [String: Any]? {
-        [
-            "client_id": clientId,
+        var result: [String: Any] = [
+            "client_id": clientConfiguration.clientId,
             "login_hint": loginHint,
             "channel_hint": channelHint.rawValue
         ]
+        
+        if let parameters = clientConfiguration.authentication.additionalParameters {
+            result.merge(parameters, uniquingKeysWith: { $1 })
+        }
+
+        return result
     }
 }

--- a/Sources/OktaDirectAuth/Internal/Step Handlers/OOBStepHandler.swift
+++ b/Sources/OktaDirectAuth/Internal/Step Handlers/OOBStepHandler.swift
@@ -45,8 +45,7 @@ class OOBStepHandler<Factor: AuthenticationFactor>: StepHandler {
                 
             case .success(let response):
                 let request = TokenRequest(openIdConfiguration: self.openIdConfiguration,
-                                           clientId: self.flow.client.configuration.clientId,
-                                           scope: self.flow.client.configuration.scopes,
+                                           clientConfiguration: self.flow.client.configuration,
                                            factor: self.factor,
                                            mfaToken: self.mfaToken,
                                            oobCode: response.oobCode,
@@ -121,7 +120,7 @@ class OOBStepHandler<Factor: AuthenticationFactor>: StepHandler {
     {
         do {
             let request = try OOBAuthenticateRequest(openIdConfiguration: openIdConfiguration,
-                                                     clientId: flow.client.configuration.clientId,
+                                                     clientConfiguration: flow.client.configuration,
                                                      loginHint: loginHint,
                                                      channelHint: channel)
             request.send(to: flow.client) { result in
@@ -142,7 +141,7 @@ class OOBStepHandler<Factor: AuthenticationFactor>: StepHandler {
     {
         do {
             let request = try ChallengeRequest(openIdConfiguration: openIdConfiguration,
-                                               clientId: flow.client.configuration.clientId,
+                                               clientConfiguration: flow.client.configuration,
                                                mfaToken: mfaToken,
                                                challengeTypesSupported: [factor.grantType])
             request.send(to: flow.client) { result in

--- a/Sources/OktaDirectAuth/Internal/Step Handlers/StepHandler.swift
+++ b/Sources/OktaDirectAuth/Internal/Step Handlers/StepHandler.swift
@@ -15,5 +15,6 @@ import AuthFoundation
 
 protocol StepHandler {
     var flow: DirectAuthenticationFlow { get }
+    
     func process(completion: @escaping (Result<DirectAuthenticationFlow.Status, DirectAuthenticationFlowError>) -> Void)
 }

--- a/Sources/OktaDirectAuth/Internal/Step Handlers/TokenStepHandler.swift
+++ b/Sources/OktaDirectAuth/Internal/Step Handlers/TokenStepHandler.swift
@@ -29,4 +29,3 @@ struct TokenStepHandler: StepHandler {
         }
     }
 }
-

--- a/Sources/OktaDirectAuth/Version.swift
+++ b/Sources/OktaDirectAuth/Version.swift
@@ -12,4 +12,6 @@
 
 @_exported import AuthFoundation
 
+// swiftlint:disable identifier_name
 public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "0.1.0")
+// swiftlint:enable identifier_name

--- a/Sources/OktaDirectAuth/Version.swift
+++ b/Sources/OktaDirectAuth/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "0.1.0")
+public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "1.4.0")
 // swiftlint:enable identifier_name

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -268,8 +268,7 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
             switch result {
             case .success(let configuration):
                 let request = TokenRequest(openIdConfiguration: configuration,
-                                           clientId: self.client.configuration.clientId,
-                                           scope: self.client.configuration.scopes,
+                                           clientConfiguration: self.client.configuration,
                                            redirectUri: self.redirectUri.absoluteString,
                                            grantType: .authorizationCode,
                                            grantValue: code,

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -294,7 +294,7 @@ extension DeviceAuthorizationFlow {
     /// - Returns: The information a user should be presented with to continue authorization on a different device.
     public func start() async throws -> Context {
         try await withCheckedThrowingContinuation { continuation in
-            start() { result in
+            start { result in
                 continuation.resume(with: result)
             }
         }

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -140,7 +140,6 @@ extension ResourceOwnerFlow {
 }
 #endif
 
-
 extension ResourceOwnerFlow: UsesDelegateCollection {
     public typealias Delegate = AuthenticationDelegate
 }

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -213,7 +213,7 @@ final class SessionTokenFlowExchange: NSObject, SessionTokenFlowURLExchange, URL
     func follow(url: URL, completion: @escaping (Result<URL, OAuth2Error>) -> Void) {
         self.completion = completion
 
-        activeTask = session.dataTask(with: URLRequest(url: url)) { [weak self] data, response, error in
+        activeTask = session.dataTask(with: URLRequest(url: url)) { [weak self] _, _, error in
             if let error = error {
                 self?.finish(with: .error(error))
             } else {

--- a/Sources/OktaOAuth2/Extensions/ErrorExtensions.swift
+++ b/Sources/OktaOAuth2/Extensions/ErrorExtensions.swift
@@ -52,7 +52,7 @@ extension AuthorizationCodeFlow.RedirectError: LocalizedError {
                                      bundle: .oktaOAuth2,
                                      comment: "Invalid URL")
 
-        case .unexpectedScheme(_):
+        case .unexpectedScheme:
             return NSLocalizedString("unexpected_scheme_description",
                                      tableName: "OktaOAuth2",
                                      bundle: .oktaOAuth2,
@@ -64,7 +64,7 @@ extension AuthorizationCodeFlow.RedirectError: LocalizedError {
                                      bundle: .oktaOAuth2,
                                      comment: "Invalid URL")
         
-        case .invalidState(_):
+        case .invalidState:
             return NSLocalizedString("invalid_state_description",
                                      tableName: "OktaOAuth2",
                                      bundle: .oktaOAuth2,

--- a/Sources/OktaOAuth2/Internal/Bundle+OktaOAuth2.swift
+++ b/Sources/OktaOAuth2/Internal/Bundle+OktaOAuth2.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 #if !SWIFT_PACKAGE
-fileprivate let sharedLocalizationBundle: Bundle = {
+private let sharedLocalizationBundle: Bundle = {
     Bundle(for: AuthorizationCodeFlow.self)
 }()
 #endif

--- a/Sources/OktaOAuth2/Requests/TokenExchangeFlow+Requests.swift
+++ b/Sources/OktaOAuth2/Requests/TokenExchangeFlow+Requests.swift
@@ -81,7 +81,7 @@ extension TokenExchangeFlow.TokenRequest: OAuth2TokenRequest, OAuth2APIRequest, 
         let tokensDict = tokens.map { token in
             [
                 token.key: token.value,
-                token.keyType: token.urn,
+                token.keyType: token.urn
             ]
         }.flatMap { $0 }
         
@@ -93,4 +93,3 @@ extension TokenExchangeFlow.TokenRequest: OAuth2TokenRequest, OAuth2APIRequest, 
         ].merging(tokensDict) { _, new in new }
     }
 }
-

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.3.1")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.4.0")
 // swiftlint:enable identifier_name

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -12,4 +12,6 @@
 
 @_exported import AuthFoundation
 
+// swiftlint:disable identifier_name
 public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.3.1")
+// swiftlint:enable identifier_name

--- a/Sources/WebAuthenticationUI/Internal/Bundle+WebAuthenticationUI.swift
+++ b/Sources/WebAuthenticationUI/Internal/Bundle+WebAuthenticationUI.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 #if !SWIFT_PACKAGE
-fileprivate let sharedLocalizationBundle: Bundle = {
+private let sharedLocalizationBundle: Bundle = {
     Bundle(for: WebAuthentication.self)
 }()
 #endif

--- a/Sources/WebAuthenticationUI/Internal/Options+Extensions.swift
+++ b/Sources/WebAuthenticationUI/Internal/Options+Extensions.swift
@@ -28,7 +28,7 @@ extension WebAuthentication.Option {
             return ["prompt": value.rawValue]
         case .custom(key: let key, value: let value):
             return [key: value]
-        case .maxAge(_), .state(_):
+        case .maxAge, .state:
             return [:]
         }
     }
@@ -43,7 +43,7 @@ extension Collection where Element == WebAuthentication.Option {
     var state: String? {
         guard case let .state(state) = filter({
             switch $0 {
-            case .state(_):
+            case .state:
                 return true
             default:
                 return false
@@ -58,7 +58,7 @@ extension Collection where Element == WebAuthentication.Option {
     var maxAge: TimeInterval? {
         guard case let .maxAge(result) = filter({
             switch $0 {
-            case .maxAge(_):
+            case .maxAge:
                 return true
             default:
                 return false

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -13,4 +13,6 @@
 import Foundation
 import AuthFoundation
 
+// swiftlint:disable identifier_name
 public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.3.1")
+// swiftlint:enable identifier_name

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -14,5 +14,5 @@ import Foundation
 import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.3.1")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.4.0")
 // swiftlint:enable identifier_name

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -35,6 +35,61 @@ final class OAuth2ClientTests: XCTestCase {
         urlSession = nil
         client = nil
     }
+    
+    func testInitializers() throws {
+        var client: OAuth2Client!
+        
+        client = try OAuth2Client(domain: "example.com",
+                                  clientId: "abc123",
+                                  scopes: "openid profile")
+        XCTAssertEqual(client.configuration, .init(baseURL: URL(string: "https://example.com")!,
+                                                   clientId: "abc123",
+                                                   scopes: "openid profile",
+                                                   authentication: .none))
+
+        client = OAuth2Client(baseURL: URL(string: "https://example.com")!,
+                                  clientId: "abc123",
+                                  scopes: "openid profile")
+        XCTAssertEqual(client.configuration, .init(baseURL: URL(string: "https://example.com")!,
+                                                   clientId: "abc123",
+                                                   scopes: "openid profile",
+                                                   authentication: .none))
+
+        client = try OAuth2Client(domain: "example.com",
+                                  clientId: "abc123",
+                                  scopes: "openid profile",
+                                  authentication: .clientSecret("supersecret"))
+        XCTAssertEqual(client.configuration, .init(baseURL: URL(string: "https://example.com")!,
+                                                   clientId: "abc123",
+                                                   scopes: "openid profile",
+                                                   authentication: .clientSecret("supersecret")))
+    }
+    
+    func testConfiguration() throws {
+        XCTAssertNotEqual(try OAuth2Client.Configuration(domain: "example.com",
+                                                         clientId: "abc123",
+                                                         scopes: "openid profile",
+                                                         authentication: .none),
+                          try OAuth2Client.Configuration(domain: "example.com",
+                                                                           clientId: "abc123",
+                                                                           scopes: "openid profile",
+                                                                           authentication: .clientSecret("supersecret")))
+    }
+
+    func testClientAuthentication() throws {
+        XCTAssertNotEqual(OAuth2Client.ClientAuthentication.none,
+                          .clientSecret("supersecret"))
+        XCTAssertEqual(OAuth2Client.ClientAuthentication.none, .none)
+
+        XCTAssertNotEqual(OAuth2Client.ClientAuthentication.clientSecret("supersecret1"),
+                       .clientSecret("supersecret2"))
+        XCTAssertEqual(OAuth2Client.ClientAuthentication.clientSecret("supersecret"),
+                       .clientSecret("supersecret"))
+        
+        XCTAssertNil(OAuth2Client.ClientAuthentication.none.additionalParameters)
+        XCTAssertEqual(OAuth2Client.ClientAuthentication.clientSecret("supersecret").additionalParameters,
+                       ["client_secret": "supersecret"])
+    }
 
     func testOpenIDConfiguration() throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",

--- a/Tests/OktaDirectAuthTests/RequestTests.swift
+++ b/Tests/OktaDirectAuthTests/RequestTests.swift
@@ -1,0 +1,128 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import TestCommon
+@testable import AuthFoundation
+@testable import OktaDirectAuth
+
+final class RequestTests: XCTestCase {
+    var openIdConfiguration: OpenIdConfiguration!
+    
+    override func setUpWithError() throws {
+        openIdConfiguration = try mock(from: .module,
+                                       for: "openid-configuration",
+                                       in: "MockResponses")
+    }
+
+    func testTokenRequestParameters() throws {
+        var request: TokenRequest
+        
+        // No authentication
+        request = .init(openIdConfiguration: openIdConfiguration,
+                        clientConfiguration: try .init(domain: "example.com",
+                                                       clientId: "theClientId",
+                                                       scopes: "openid profile"),
+                        factor: DirectAuthenticationFlow.PrimaryFactor.password("password123"))
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "scope": "openid profile",
+                        "grant_type": "password",
+                        "password": "password123"
+                       ])
+
+        // Client Secret authentication
+        request = .init(openIdConfiguration: openIdConfiguration,
+                        clientConfiguration: try .init(domain: "example.com",
+                                                       clientId: "theClientId",
+                                                       scopes: "openid profile",
+                                                       authentication: .clientSecret("supersecret")),
+                        factor: DirectAuthenticationFlow.PrimaryFactor.password("password123"))
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "client_secret": "supersecret",
+                        "scope": "openid profile",
+                        "grant_type": "password",
+                        "password": "password123"
+                       ])
+    }
+
+    func testOOBAuthenticateRequestParameters() throws {
+        var request: OOBAuthenticateRequest
+        
+        // No authentication
+        request = try .init(openIdConfiguration: openIdConfiguration,
+                            clientConfiguration: try .init(domain: "example.com",
+                                                           clientId: "theClientId",
+                                                           scopes: "openid profile"),
+                            loginHint: "user@example.com",
+                            channelHint: .push)
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "channel_hint": "push",
+                        "login_hint": "user@example.com"
+                       ])
+
+        // Client Secret authentication
+        request = try .init(openIdConfiguration: openIdConfiguration,
+                            clientConfiguration: try .init(domain: "example.com",
+                                                           clientId: "theClientId",
+                                                           scopes: "openid profile",
+                                                           authentication: .clientSecret("supersecret")),
+                            loginHint: "user@example.com",
+                            channelHint: .push)
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "client_secret": "supersecret",
+                        "channel_hint": "push",
+                        "login_hint": "user@example.com"
+                       ])
+    }
+
+    func testChallengeRequestParameters() throws {
+        var request: ChallengeRequest
+        
+        // No authentication
+        request = try .init(openIdConfiguration: openIdConfiguration,
+                            clientConfiguration: try .init(domain: "example.com",
+                                                           clientId: "theClientId",
+                                                           scopes: "openid profile"),
+                            mfaToken: "abcd123",
+                            challengeTypesSupported: [.password, .oob])
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "mfa_token": "abcd123",
+                        "challenge_types_supported": "password urn:okta:params:oauth:grant-type:oob"
+                       ])
+
+        // Client Secret authentication
+        request = try .init(openIdConfiguration: openIdConfiguration,
+                            clientConfiguration: try .init(domain: "example.com",
+                                                           clientId: "theClientId",
+                                                           scopes: "openid profile",
+                                                           authentication: .clientSecret("supersecret")),
+                            mfaToken: "abcd123",
+                            challengeTypesSupported: [.password, .oob])
+        XCTAssertEqual(request.bodyParameters as? [String: String],
+                       [
+                        "client_id": "theClientId",
+                        "client_secret": "supersecret",
+                        "mfa_token": "abcd123",
+                        "challenge_types_supported": "password urn:okta:params:oauth:grant-type:oob"
+                       ])
+    }
+}

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -23,15 +23,6 @@ final class OAuth2ClientTests: XCTestCase {
         Token.resetToDefault()
     }
     
-    func openIdConfiguration(named: String = "openid-configuration") throws -> (OpenIdConfiguration, Data) {
-        let data = try data(from: .module,
-                           for: named,
-                           in: "MockResponses")
-        let configuration = try OpenIdConfiguration.jsonDecoder.decode(OpenIdConfiguration.self,
-                                                                       from: data)
-        return (configuration, data)
-    }
-
     func testAuthorizationCodeConstructor() throws {
         let flow = AuthorizationCodeFlow(issuer: issuer,
                                          clientId: "theClientId",
@@ -43,9 +34,11 @@ final class OAuth2ClientTests: XCTestCase {
     func testExchange() throws {
         let pkce = PKCE()
         let (openIdConfiguration, openIdData) = try openIdConfiguration()
+        let clientConfiguration = try OAuth2Client.Configuration(domain: "example.com",
+                                                                 clientId: "client_id",
+                                                                 scopes: "openid profile offline_access")
         let request = AuthorizationCodeFlow.TokenRequest(openIdConfiguration: openIdConfiguration,
-                                                         clientId: "client_id",
-                                                         scope: "openid profile offline_access",
+                                                         clientConfiguration: clientConfiguration,
                                                          redirectUri: redirectUri.absoluteString,
                                                          grantType: .authorizationCode,
                                                          grantValue: "abc123",
@@ -90,9 +83,11 @@ final class OAuth2ClientTests: XCTestCase {
     func testExchangeFailed() throws {
         let pkce = PKCE()
         let (openIdConfiguration, openIdData) = try openIdConfiguration(named: "openid-configuration-invalid-issuer")
+        let clientConfiguration = try OAuth2Client.Configuration(domain: "example.com",
+                                                                 clientId: "client_id",
+                                                                 scopes: "openid profile offline_access")
         let request = AuthorizationCodeFlow.TokenRequest(openIdConfiguration: openIdConfiguration,
-                                                         clientId: "client_id",
-                                                         scope: "openid profile offline_access",
+                                                         clientConfiguration: clientConfiguration,
                                                          redirectUri: redirectUri.absoluteString,
                                                          grantType: .authorizationCode,
                                                          grantValue: "abc123",

--- a/Tests/OktaOAuth2Tests/Utilities/XCTestCase+Extensions.swift
+++ b/Tests/OktaOAuth2Tests/Utilities/XCTestCase+Extensions.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2023-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+import XCTest
+import AuthFoundation
+
+extension XCTestCase {
+    func openIdConfiguration(named: String = "openid-configuration") throws -> (OpenIdConfiguration, Data) {
+        let data = try data(from: .module,
+                           for: named,
+                           in: "MockResponses")
+        let configuration = try OpenIdConfiguration.jsonDecoder.decode(OpenIdConfiguration.self,
+                                                                       from: data)
+        return (configuration, data)
+    }
+}


### PR DESCRIPTION
This is required for some use-cases of the Direct Auth API.

To use this, a developer would create an instance of OAuth2Client directly, and supply that to their desired authentication flow.  For example:

```swift
let client = OAuth2Client(domain: "example.com",
                          clientId: "theClientId",
                          scopes: "openid profile",
                          authentication: .clientSecret("super secret"))
let flow = DirectAuthenticationFlow(client: client)
// Magic Happens
```