### PR TITLE
Fix migration of tokens from previous releases

### DIFF
--- a/Sources/AuthFoundation/OAuth2/Configuration.swift
+++ b/Sources/AuthFoundation/OAuth2/Configuration.swift
@@ -77,6 +77,15 @@ extension OAuth2Client {
             self.init(baseURL: url, clientId: clientId, scopes: scopes, authentication: authentication)
         }
         
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.baseURL = try container.decode(URL.self, forKey: .baseURL)
+            self.discoveryURL = try container.decode(URL.self, forKey: .discoveryURL)
+            self.clientId = try container.decode(String.self, forKey: .clientId)
+            self.scopes = try container.decode(String.self, forKey: .scopes)
+            self.authentication = try container.decodeIfPresent(OAuth2Client.ClientAuthentication.self, forKey: .authentication) ?? .none
+        }
+        
         public static func == (lhs: OAuth2Client.Configuration, rhs: OAuth2Client.Configuration) -> Bool {
             lhs.baseURL == rhs.baseURL &&
             lhs.clientId == rhs.clientId &&

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -71,6 +71,7 @@ extension Credential {
     /// * ``Token/RevokeType/accessToken`` – Revokes the access token. If the `offline_access` scope was specified when authenticating, the refresh token may be used to recreate a new access token.
     /// * ``Token/RevokeType/refreshToken`` – If a refresh token is present (e.g. the `offline_access` scope was specified when authenticating), both the access token _and_ refresh token will become invalidated.
     /// * ``Token/RevokeType/deviceSecret`` – If the `device_sso` scope was specified when authenticating, this will invalidate the device secret, which will prevent other clients from creating new tokens using Device SSO.
+    /// * ``Token/RevokeType/all`` - Revokes all applicable tokens associated with this object.
     ///
     /// If a credential is no longer valid, it will automatically be removed from storage. This is to prevent an application from thinking a valid user is signed in while having credentials that are incapable of being used.
     ///

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -35,10 +35,15 @@ final class CredentialCoordinatorImpl: CredentialCoordinator {
     }
         
     private lazy var _default: Credential? = {
-        try? CredentialCoordinatorImpl.defaultCredential(
-            tokenStorage: tokenStorage,
-            credentialDataSource: credentialDataSource,
-            coordinator: self)
+        do {
+            return try CredentialCoordinatorImpl.defaultCredential(
+                tokenStorage: tokenStorage,
+                credentialDataSource: credentialDataSource,
+                coordinator: self)
+        } catch {
+            // Placeholder for when logging is added in a future release
+            return nil
+        }
     }()
     var `default`: Credential? {
         get { _default }


### PR DESCRIPTION
There was an added attribute to the OAuth2 client configuration, but it didn't account for migrations when the value was not present from previous releases. This fixes #138 