### PR TITLE
Obvious Fix: Change minimum iOS version from 15 to 13 where possible

### DIFF
--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -69,7 +69,7 @@ public protocol APIRequest {
     ///   - client: ``APIClient`` the request is being sent to.
     ///   - context: Optional context to use when parsing the response.
     /// - Returns: ``APIResponse`` result of the request.
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func send(to client: APIClient, parsing context: APIParsingContext?) async throws -> APIResponse<ResponseType>
     #endif
 }
@@ -243,7 +243,7 @@ extension APIRequest {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     public func send(to client: APIClient, parsing context: APIParsingContext? = nil) async throws -> APIResponse<ResponseType> {
         try await withCheckedThrowingContinuation { continuation in
             send(to: client, parsing: context) { result in

--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -69,7 +69,7 @@ public protocol APIRequest {
     ///   - client: ``APIClient`` the request is being sent to.
     ///   - context: Optional context to use when parsing the response.
     /// - Returns: ``APIResponse`` result of the request.
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func send(to client: APIClient, parsing context: APIParsingContext?) async throws -> APIResponse<ResponseType>
     #endif
 }
@@ -243,7 +243,7 @@ extension APIRequest {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     public func send(to client: APIClient, parsing context: APIParsingContext? = nil) async throws -> APIResponse<ResponseType> {
         try await withCheckedThrowingContinuation { continuation in
             send(to: client, parsing: context) { result in

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -541,7 +541,7 @@ public final class OAuth2Client {
 // swiftlint:enable type_body_length
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension OAuth2Client {
     /// Asynchronously retrieves the org's OpenID configuration.
     ///

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -541,7 +541,7 @@ public final class OAuth2Client {
 // swiftlint:enable type_body_length
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension OAuth2Client {
     /// Asynchronously retrieves the org's OpenID configuration.
     ///

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -212,7 +212,7 @@ public final class Token: Codable, Equatable, Hashable, Expires {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension Token {
     /// Creates a new Token from a refresh token.
     /// - Parameters:

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -212,7 +212,7 @@ public final class Token: Codable, Equatable, Hashable, Expires {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension Token {
     /// Creates a new Token from a refresh token.
     /// - Parameters:

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -36,7 +36,7 @@ extension Notification.Name {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension Credential {
     /// Attempt to refresh the token.
     public func refresh() async throws {

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -36,7 +36,7 @@ extension Notification.Name {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension Credential {
     /// Attempt to refresh the token.
     public func refresh() async throws {

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -277,7 +277,7 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension DirectAuthenticationFlow {
     /// Start user authentication, with the given username login hint and primary factor.
     /// - Parameters:

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -277,7 +277,7 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension DirectAuthenticationFlow {
     /// Start user authentication, with the given username login hint and primary factor.
     /// - Parameters:

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -305,7 +305,7 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension AuthorizationCodeFlow {
     /// Asynchronously initiates an authentication flow, with an optional ``Context-swift.struct``, using Swift Concurrency.
     ///

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -305,7 +305,7 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension AuthorizationCodeFlow {
     /// Asynchronously initiates an authentication flow, with an optional ``Context-swift.struct``, using Swift Concurrency.
     ///

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -284,7 +284,7 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension DeviceAuthorizationFlow {
     /// Asynchronously initiates a device authentication flow.
     ///

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -284,7 +284,7 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension DeviceAuthorizationFlow {
     /// Asynchronously initiates a device authentication flow.
     ///

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -125,7 +125,7 @@ public class ResourceOwnerFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension ResourceOwnerFlow {
     /// Asynchronously authenticates with the Resource Owner flow.
     ///

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -125,7 +125,7 @@ public class ResourceOwnerFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension ResourceOwnerFlow {
     /// Asynchronously authenticates with the Resource Owner flow.
     ///

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -175,7 +175,7 @@ public class SessionTokenFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension SessionTokenFlow {
     /// Asynchronously authenticates with the given session token.
     public func start(with sessionToken: String,

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -175,7 +175,7 @@ public class SessionTokenFlow: AuthenticationFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension SessionTokenFlow {
     /// Asynchronously authenticates with the given session token.
     public func start(with sessionToken: String,

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -156,7 +156,7 @@ extension TokenExchangeFlow: OAuth2ClientDelegate {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension TokenExchangeFlow {
     /// Asynchronously initiates a token exchange flow.
     /// - Parameter tokens: Tokens to exchange. If empty, the method throws an error.

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -156,7 +156,7 @@ extension TokenExchangeFlow: OAuth2ClientDelegate {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension TokenExchangeFlow {
     /// Asynchronously initiates a token exchange flow.
     /// - Parameter tokens: Tokens to exchange. If empty, the method throws an error.

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
@@ -219,7 +219,7 @@ public class SessionLogoutFlow: LogoutFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension SessionLogoutFlow {
     /// Asynchronously initiates a logout flow, with a required ID Token.
     ///

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
@@ -219,7 +219,7 @@ public class SessionLogoutFlow: LogoutFlow {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension SessionLogoutFlow {
     /// Asynchronously initiates a logout flow, with a required ID Token.
     ///

--- a/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
+++ b/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
@@ -95,7 +95,7 @@ extension WebAuthentication {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension WebAuthentication {
     @available(*, deprecated, renamed: "signIn(from:options:)")
     public final func signIn(from window: WindowAnchor?,

--- a/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
+++ b/Sources/WebAuthenticationUI/Extensions/WebAuthentication+Deprecated.swift
@@ -95,7 +95,7 @@ extension WebAuthentication {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension WebAuthentication {
     @available(*, deprecated, renamed: "signIn(from:options:)")
     public final func signIn(from window: WindowAnchor?,

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -405,7 +405,7 @@ public class WebAuthentication {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
 extension WebAuthentication {
     /// Asynchronously initiates authentication from the given window.
     /// - Parameters:

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -405,7 +405,7 @@ public class WebAuthentication {
 }
 
 #if swift(>=5.5.1)
-@available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
 extension WebAuthentication {
     /// Asynchronously initiates authentication from the given window.
     /// - Parameters:

--- a/Tests/AuthFoundationTests/CredentialRefreshTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRefreshTests.swift
@@ -312,26 +312,26 @@ final class CredentialRefreshTests: XCTestCase, OAuth2ClientDelegate {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRefreshAsync() async throws {
         let credential = try credential(for: Token.simpleMockToken)
         try await credential.refresh()
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRefreshIfNeededExpiredAsync() async throws {
         let credential = try credential(for: Token.mockToken(issuedOffset: 6000))
         try await credential.refreshIfNeeded(graceInterval: 300)
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRefreshIfNeededWithinGraceIntervalAsync() async throws {
         let credential = try credential(for: Token.mockToken(issuedOffset: 0),
                                            expectAPICalls: .none)
         try await credential.refreshIfNeeded(graceInterval: 300)
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRefreshIfNeededOutsideGraceIntervalAsync() async throws {
             let credential = try credential(for: Token.mockToken(issuedOffset: 3500))
         try await credential.refreshIfNeeded(graceInterval: 300)

--- a/Tests/AuthFoundationTests/CredentialRefreshTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRefreshTests.swift
@@ -312,26 +312,26 @@ final class CredentialRefreshTests: XCTestCase, OAuth2ClientDelegate {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRefreshAsync() async throws {
         let credential = try credential(for: Token.simpleMockToken)
         try await credential.refresh()
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRefreshIfNeededExpiredAsync() async throws {
         let credential = try credential(for: Token.mockToken(issuedOffset: 6000))
         try await credential.refreshIfNeeded(graceInterval: 300)
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRefreshIfNeededWithinGraceIntervalAsync() async throws {
         let credential = try credential(for: Token.mockToken(issuedOffset: 0),
                                            expectAPICalls: .none)
         try await credential.refreshIfNeeded(graceInterval: 300)
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRefreshIfNeededOutsideGraceIntervalAsync() async throws {
             let credential = try credential(for: Token.mockToken(issuedOffset: 3500))
         try await credential.refreshIfNeeded(graceInterval: 300)

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -532,7 +532,7 @@ final class OAuth2ClientTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRefreshAsync() async throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
@@ -544,7 +544,7 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertNotNil(token)
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testRevokeAsync() async throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -532,7 +532,7 @@ final class OAuth2ClientTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRefreshAsync() async throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
@@ -544,7 +544,7 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertNotNil(token)
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testRevokeAsync() async throws {
         urlSession.expect("https://example.com/.well-known/openid-configuration",
                           data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),

--- a/Tests/AuthFoundationTests/TokenTests.swift
+++ b/Tests/AuthFoundationTests/TokenTests.swift
@@ -134,7 +134,7 @@ final class TokenTests: XCTestCase {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testTokenFromRefreshTokenAsync() async throws {
         let client = try mockClient()
         let token = try await Token.from(refreshToken: "the_refresh_token", using: client)

--- a/Tests/AuthFoundationTests/TokenTests.swift
+++ b/Tests/AuthFoundationTests/TokenTests.swift
@@ -134,7 +134,7 @@ final class TokenTests: XCTestCase {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testTokenFromRefreshTokenAsync() async throws {
         let client = try mockClient()
         let token = try await Token.from(refreshToken: "the_refresh_token", using: client)

--- a/Tests/OktaDirectAuthTests/DirectAuth1FATests.swift
+++ b/Tests/OktaDirectAuthTests/DirectAuth1FATests.swift
@@ -42,7 +42,7 @@ final class DirectAuth1FATests: XCTestCase {
     }
     
 #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testUserAndPassword() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)
@@ -60,7 +60,7 @@ final class DirectAuth1FATests: XCTestCase {
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testUserAndOTP() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)
@@ -78,7 +78,7 @@ final class DirectAuth1FATests: XCTestCase {
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testUserAndOOBPush() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaDirectAuthTests/DirectAuth1FATests.swift
+++ b/Tests/OktaDirectAuthTests/DirectAuth1FATests.swift
@@ -42,7 +42,7 @@ final class DirectAuth1FATests: XCTestCase {
     }
     
 #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testUserAndPassword() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)
@@ -60,7 +60,7 @@ final class DirectAuth1FATests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testUserAndOTP() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)
@@ -78,7 +78,7 @@ final class DirectAuth1FATests: XCTestCase {
         }
     }
 
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testUserAndOOBPush() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaDirectAuthTests/DirectAuth2FATests.swift
+++ b/Tests/OktaDirectAuthTests/DirectAuth2FATests.swift
@@ -42,7 +42,7 @@ final class DirectAuth2FATests: XCTestCase {
     }
     
 #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testUserPasswordAndOOB() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaDirectAuthTests/DirectAuth2FATests.swift
+++ b/Tests/OktaDirectAuthTests/DirectAuth2FATests.swift
@@ -42,7 +42,7 @@ final class DirectAuth2FATests: XCTestCase {
     }
     
 #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testUserPasswordAndOOB() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
@@ -175,7 +175,7 @@ final class AuthorizationCodeFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertNil(flow.context)

--- a/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
@@ -175,7 +175,7 @@ final class AuthorizationCodeFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertNil(flow.context)

--- a/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
@@ -140,7 +140,7 @@ final class DeviceAuthorizationFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertNil(flow.context)

--- a/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
@@ -140,7 +140,7 @@ final class DeviceAuthorizationFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertNil(flow.context)

--- a/Tests/OktaOAuth2Tests/ResourceOwnerFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/ResourceOwnerFlowTests.swift
@@ -118,7 +118,7 @@ final class ResourceOwnerFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaOAuth2Tests/ResourceOwnerFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/ResourceOwnerFlowTests.swift
@@ -118,7 +118,7 @@ final class ResourceOwnerFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
@@ -149,7 +149,7 @@ final class SessionLogoutFlowSuccessTests: XCTestCase {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testWithAsync() async throws {
         XCTAssertNil(flow.context)
         XCTAssertFalse(flow.inProgress)

--- a/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
@@ -149,7 +149,7 @@ final class SessionLogoutFlowSuccessTests: XCTestCase {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testWithAsync() async throws {
         XCTAssertNil(flow.context)
         XCTAssertFalse(flow.inProgress)

--- a/Tests/OktaOAuth2Tests/SessionTokenFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionTokenFlowTests.swift
@@ -127,7 +127,7 @@ final class SessionTokenFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaOAuth2Tests/SessionTokenFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionTokenFlowTests.swift
@@ -127,7 +127,7 @@ final class SessionTokenFlowSuccessTests: XCTestCase {
     }
 
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testWithAsync() async throws {
         // Ensure the initial state
         XCTAssertFalse(flow.isAuthenticating)

--- a/Tests/OktaOAuth2Tests/TokenExchangeFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/TokenExchangeFlowTests.swift
@@ -125,7 +125,7 @@ final class TokenExchangeFlowTests: XCTestCase {
     }
     
 #if swift(>=5.5.1) && !os(Linux)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func testAsyncAuthenticationSucceeded() async throws {
         XCTAssertFalse(flow.isAuthenticating)
         

--- a/Tests/OktaOAuth2Tests/TokenExchangeFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/TokenExchangeFlowTests.swift
@@ -125,7 +125,7 @@ final class TokenExchangeFlowTests: XCTestCase {
     }
     
 #if swift(>=5.5.1) && !os(Linux)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func testAsyncAuthenticationSucceeded() async throws {
         XCTAssertFalse(flow.isAuthenticating)
         

--- a/Tests/TestCommon/URLSessionMock.swift
+++ b/Tests/TestCommon/URLSessionMock.swift
@@ -92,7 +92,7 @@ class URLSessionMock: URLSessionProtocol {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         requests.append(request)
 

--- a/Tests/TestCommon/URLSessionMock.swift
+++ b/Tests/TestCommon/URLSessionMock.swift
@@ -92,7 +92,7 @@ class URLSessionMock: URLSessionProtocol {
     }
     
     #if swift(>=5.5.1)
-    @available(iOS 13.0, tvOS 15.0, macOS 12.0, watchOS 8, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
     func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
         requests.append(request)
 


### PR DESCRIPTION
All async/await APIs are currently only available for iOS 15 but the minimum requirement for async/await is iOS 13. This PR changes the minimum iOS version from 15 to 13 where possible.