### PR TITLE
Using discovery url

### DIFF
--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -131,7 +131,7 @@ public final class OAuth2Client {
                 
                 openIdConfigurationAction = action
                 
-                let request = OpenIdConfigurationRequest(baseURL: baseURL)
+                let request = OpenIdConfigurationRequest(url: configuration.discoveryURL)
                 request.send(to: self) { result in
                     self.configurationQueue.sync(flags: .barrier) {
                         self.openIdConfigurationAction = nil

--- a/Sources/AuthFoundation/Requests/OpenIdConfigurationRequest.swift
+++ b/Sources/AuthFoundation/Requests/OpenIdConfigurationRequest.swift
@@ -18,10 +18,6 @@ import FoundationNetworking
 
 struct OpenIdConfigurationRequest {
     let url: URL
-    
-    init(baseURL: URL) {
-        url = baseURL.appendingPathComponent(".well-known/openid-configuration")
-    }
 }
 
 extension OpenIdConfigurationRequest: APIRequest {


### PR DESCRIPTION
**Enhancements in OAuth2Client & OpenIdConfigurationRequest**

- Properly utilize the passed discovery URL in `OAuth2Client.swift`. Previously, it was only being set but not used.
  
- Eliminated redundant logic: The logic to append `.well-known` to the URL was duplicated in both `OpenIdConfigurationRequest` and the `OAuth2Client.swift` initializer. This has now been streamlined, removing the redundancy from `OpenIdConfigurationRequest`.

---