### PR TITLE
Ensure the default URLSession for OAuth2Client is ephemeral

### DIFF
--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaAuthFoundation"
     s.module_name      = "AuthFoundation"
-    s.version          = "1.4.2"
+    s.version          = "1.4.3"
     s.summary          = "Okta Authentication Foundation"
     s.description      = <<-DESC
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.

--- a/OktaDirectAuth.podspec
+++ b/OktaDirectAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaDirectAuth"
-    s.version          = "1.4.2"
+    s.version          = "1.4.3"
     s.summary          = "Okta Direct Authentication"
     s.description      = <<-DESC
 Enables application developers to build native sign in experiences using the Okta Direct Authentication API.

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.4.2"
+    s.version          = "1.4.3"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.4.2"
+    s.version          = "1.4.3"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.4.2   | ✔️ Stable                             |
+| 1.4.3   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -104,7 +104,7 @@ public final class OAuth2Client {
         _ = Date.coordinator
         
         self.configuration = configuration
-        self.session = session ?? URLSession.shared
+        self.session = session ?? URLSession(configuration: .ephemeral)
         
         NotificationCenter.default.post(name: .oauth2ClientCreated, object: self)
 

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -13,5 +13,5 @@
 import Foundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.4.2")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.4.3")
 // swiftlint:enable identifier_name

--- a/Sources/OktaDirectAuth/Version.swift
+++ b/Sources/OktaDirectAuth/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "1.4.2")
+public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "1.4.3")
 // swiftlint:enable identifier_name

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.4.2")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.4.3")
 // swiftlint:enable identifier_name

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -14,5 +14,5 @@ import Foundation
 import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.4.2")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.4.3")
 // swiftlint:enable identifier_name

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -53,6 +53,10 @@ final class OAuth2ClientTests: XCTestCase {
                                                    clientId: "abc123",
                                                    scopes: "openid profile",
                                                    authentication: .none))
+        
+        // Ensure the default session is ephemeral
+        let urlSession = try XCTUnwrap(client.session as? URLSession)
+        XCTAssertEqual(urlSession.configuration.urlCache?.diskCapacity, 0)
 
         client = OAuth2Client(baseURL: URL(string: "https://example.com")!,
                                   clientId: "abc123",


### PR DESCRIPTION
Certain versions of macOS provides a `URLSession.shared` instance that uses a persistent URL cache, whereas newer versions do not.  Since the `/oauth2/v1/keys` endpoint has a long cache expiry (~= 10 days), when keys are rotated on the server, users may not be unable to sign in unless they clear the cache (or delete and reinstall the app).

Since other parts of the SDK explicitly uses an ephemeral session already, this looks an oversight, so it’s good to make our uses of URLSession consistent across the SDK.