### PR TITLE
fix client id matching

### DIFF
--- a/Sources/AuthFoundation/Migration/Migrators/OIDCLegacyMigrator.swift
+++ b/Sources/AuthFoundation/Migration/Migrators/OIDCLegacyMigrator.swift
@@ -95,7 +95,8 @@ extension SDKVersion.Migration {
             let results = items.filter({ searchResult in
                 // swiftlint:disable empty_string
                 guard searchResult.service == "",
-                      regex.matches(in: searchResult.account, range: NSRange(location: 0, length: searchResult.account.count)).count == 1
+                      clientId == searchResult.account ||
+                          regex.matches(in: searchResult.account, range: NSRange(location: 0, length: searchResult.account.count)).count == 1
                 else {
                     return false
                 }
@@ -115,8 +116,9 @@ extension SDKVersion.Migration {
                 .Search(service: "")
                 .list()
                 .filter({ searchResult in
-                    regex.matches(in: searchResult.account,
-                                  range: NSRange(location: 0, length: searchResult.account.count)).count == 1
+                    clientId == searchResult.account ||
+                        regex.matches(in: searchResult.account,
+                                      range: NSRange(location: 0, length: searchResult.account.count)).count == 1
                 }).map({ searchResult in
                     let item = try searchResult.get()
                     return (searchResult, try decode(item.value))

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -298,7 +298,6 @@ public class WebAuthentication {
     ///   - issuer: The URL for the OAuth2 issuer.
     ///   - clientId: The client's ID.
     ///   - scopes: The scopes the client is requesting.
-    ///   - responseType: The response type to expect.
     ///   - redirectUri: The redirect URI for the configured client.
     ///   - logoutRedirectUri: The logout URI for the client, if applicable.
     ///   - additionalParameters: Optional parameters to add to the authorization query string.

--- a/Tests/AuthFoundationTests/OIDCLegacyMigratorTests.swift
+++ b/Tests/AuthFoundationTests/OIDCLegacyMigratorTests.swift
@@ -96,8 +96,22 @@ final class OIDCLegacyMigratorTests: XCTestCase {
             ]
         ] as CFArray)
         XCTAssertTrue(migrator.needsMigration)
+
+        // Test that a clientId match counts as a match
+        keychain.expect(noErr, result: [
+            [
+                "svce": "",
+                "acct": "clientId",
+                "class": "genp",
+                "cdat": Date(),
+                "mdat": Date(),
+                "pdmn": "ak",
+                "agrp": "com.okta.sample.app"
+            ]
+        ] as CFArray)
+        XCTAssertTrue(migrator.needsMigration)
     }
-    
+
     func testMigrate() throws {
         let notificationRecorder = NotificationRecorder(observing: [ .credentialMigrated ])
         


### PR DESCRIPTION
Client IDs for 1st party apps (like Okta Personal's iOS app) have don't match the regex. Since we have access to the client ID, we can first do a check against that instead of the regex, then default the the current behavior if that doesn't work.

This PR:

- covers the failing scenario with a unit test
- fixes the failing scenario
- also fixes a small documentation issue (removes a parameter from the docs that isn't in the actual function)