### PR TITLE
Fix crash when using `try await credential.revoke()` if removal from token storage fails

### DIFF
--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -229,12 +229,10 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
         let shouldRemove = shouldRemove(for: type)
         
         oauth2.revoke(token, type: type) { result in
-            defer { completion?(result) }
-            
-            guard case .success = result else { return }
-            
             // Remove the credential from storage if the access token was revoked
-            if shouldRemove {
+            if case .success = result,
+               shouldRemove
+            {
                 do {
                     try self.coordinator?.remove(credential: self)
                 } catch let error as OAuth2Error {
@@ -245,6 +243,8 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
                     return
                 }
             }
+            
+            completion?(result)
         }
     }
     

--- a/Tests/AuthFoundationTests/CredentialRevokeTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRevokeTests.swift
@@ -189,4 +189,91 @@ final class CredentialTests: XCTestCase {
         XCTAssertEqual(deviceSecretRequest.bodyString,
                        "client_id=foo&token=device123&token_type_hint=device_secret")
     }
+    
+    func testFailureAfterRevokeAccessToken() throws {
+        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/revoke",
+                          data: Data())
+        
+        XCTAssertEqual(coordinator.credentialDataSource.credentialCount, 1)
+        XCTAssertTrue(coordinator.credentialDataSource.hasCredential(for: token))
+
+        let storage = try XCTUnwrap(coordinator.tokenStorage as? MockTokenStorage)
+        storage.error = CredentialError.metadataConsistency
+        
+        let expect = expectation(description: "network request")
+        credential.revoke(type: .accessToken) { result in
+            switch result {
+            case .success(): break
+            case .failure(let error):
+                XCTAssertNil(error)
+            }
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1.0) { error in
+            XCTAssertNil(error)
+        }
+
+        XCTAssertEqual(coordinator.credentialDataSource.credentialCount, 1)
+        XCTAssertTrue(coordinator.credentialDataSource.hasCredential(for: token))
+    }
+
+    #if swift(>=5.5.1)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
+    func testRevokeFailureAsync() async throws {
+        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/revoke",
+                          data: data(for: """
+                                        {"error": "invalid_token", "errorDescription": "Invalid token"}
+                                    """),
+                          statusCode: 400,
+                          contentType: "application/json")
+        
+        do {
+            try await credential.revoke(type: .accessToken)
+        } catch {
+            guard let oauth2Error = error as? OAuth2Error,
+                  case let .network(error: apiError) = oauth2Error,
+                  case let .serverError(serverError) = apiError,
+                  let oauth2Error = serverError as? OAuth2ServerError
+            else {
+                XCTFail()
+                return
+            }
+            
+            XCTAssertEqual(oauth2Error.code, .invalidToken)
+        }
+    }
+    
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
+    func testFailureAfterRevokeAccessTokenAsync() async throws {
+        urlSession.expect("https://example.com/oauth2/default/.well-known/openid-configuration",
+                          data: try data(from: .module, for: "openid-configuration", in: "MockResponses"),
+                          contentType: "application/json")
+        urlSession.expect("https://example.com/oauth2/v1/revoke",
+                          data: Data())
+        urlSession.expect("https://example.com/oauth2/v1/revoke",
+                          data: Data())
+        urlSession.expect("https://example.com/oauth2/v1/revoke",
+                          data: Data())
+
+        XCTAssertEqual(coordinator.credentialDataSource.credentialCount, 1)
+        XCTAssertTrue(coordinator.credentialDataSource.hasCredential(for: token))
+
+        let storage = try XCTUnwrap(coordinator.tokenStorage as? MockTokenStorage)
+        storage.error = OAuth2Error.invalidUrl
+        
+        do {
+            try await credential.revoke()
+        } catch let error as OAuth2Error {
+            XCTAssert(error == .invalidUrl)
+        } catch {
+            XCTFail()
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
Ensures completion blocks are called appropriately when removing tokens from storage fails after a successful revoke

In these cases, the completion block could be called multiple times, which breaks the swift concurrency lifecycle.

This fixes #169 