### PR TITLE
Updates to support Cocoapods

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,6 +40,23 @@ jobs:
     - name: Test
       run: swift test --parallel
 
+  Cocoapods:
+    name: CocoaPods Build
+    runs-on: macos-12
+    timeout-minutes: 10
+    needs:
+      - SwiftBuild
+    steps:
+    - uses: actions/checkout@master
+    - name: OktaAuthFoundation.podspec
+      run: pod lib lint --allow-warnings OktaAuthFoundation.podspec
+    - name: OktaOAuth2.podspec
+      run: pod lib lint --allow-warnings OktaOAuth2.podspec
+    - name: OktaDirectAuth.podspec
+      run: pod lib lint --allow-warnings OktaDirectAuth.podspec
+    - name: OktaWebAuthenticationUI.podspec
+      run: pod lib lint --allow-warnings OktaWebAuthenticationUI.podspec
+
   XcodeBuild:
     name: Xcode Unit Tests
     runs-on: macos-12

--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -7,15 +7,15 @@ Pod::Spec.new do |s|
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.
                          DESC
     s.platforms = {
-        :ios     => "9.0",
+        :ios     => "10.0",
         :tvos    => "10.0",
         :watchos => "7.0",
-        :osx     => "10.11"
+        :osx     => "10.12"
     }
-    s.ios.deployment_target     = "9.0"
+    s.ios.deployment_target     = "10.0"
     s.tvos.deployment_target    = "10.0"
     s.watchos.deployment_target = "7.0"
-    s.osx.deployment_target     = "10.11"
+    s.osx.deployment_target     = "10.12"
 
     s.homepage      = "https://github.com/okta/okta-mobile-swift"
     s.license       = { :type => "APACHE2", :file => "LICENSE" }
@@ -23,5 +23,5 @@ Provides the foundation and common features used to authenticate users, managing
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/AuthFoundation/**/*.swift"
     s.resources     = "Sources/AuthFoundation/Resources/*.lproj"
-    s.swift_version = "5.5"
+    s.swift_version = "5.6"
 end

--- a/OktaDirectAuth.podspec
+++ b/OktaDirectAuth.podspec
@@ -6,15 +6,15 @@ Pod::Spec.new do |s|
 Enables application developers to build native sign in experiences using the Okta Direct Authentication API.
                          DESC
     s.platforms = {
-        :ios     => "9.0",
+        :ios     => "10.0",
         :tvos    => "10.0",
         :watchos => "7.0",
-        :osx     => "10.11"
+        :osx     => "10.12"
     }
-    s.ios.deployment_target     = "9.0"
+    s.ios.deployment_target     = "10.0"
     s.tvos.deployment_target    = "10.0"
     s.watchos.deployment_target = "7.0"
-    s.osx.deployment_target     = "10.11"
+    s.osx.deployment_target     = "10.12"
 
     s.homepage      = "https://github.com/okta/okta-mobile-swift"
     s.license       = { :type => "APACHE2", :file => "LICENSE" }
@@ -22,7 +22,7 @@ Enables application developers to build native sign in experiences using the Okt
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/OktaDirectAuth/**/*.swift"
     s.resources     = "Sources/OktaDirectAuth/Resources/*.lproj"
-    s.swift_version = "5.5"
+    s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"
 end

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -6,15 +6,15 @@ Pod::Spec.new do |s|
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.
                          DESC
     s.platforms = {
-        :ios     => "9.0",
+        :ios     => "10.0",
         :tvos    => "10.0",
         :watchos => "7.0",
-        :osx     => "10.11"
+        :osx     => "10.12"
     }
-    s.ios.deployment_target     = "9.0"
+    s.ios.deployment_target     = "10.0"
     s.tvos.deployment_target    = "10.0"
     s.watchos.deployment_target = "7.0"
-    s.osx.deployment_target     = "10.11"
+    s.osx.deployment_target     = "10.12"
 
     s.homepage      = "https://github.com/okta/okta-mobile-swift"
     s.license       = { :type => "APACHE2", :file => "LICENSE" }
@@ -22,7 +22,7 @@ Enables application developers to authenticate users utilizing a variety of OAut
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/OktaOAuth2/**/*.swift"
     s.resources     = "Sources/OktaOAuth2/Resources/*.lproj"
-    s.swift_version = "5.5"
+    s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"
 end

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -7,11 +7,11 @@ Pod::Spec.new do |s|
 Authenticate users using web-based OIDC.
                          DESC
     s.platforms = {
-        :ios => "9.0",
-        :osx => "10.11"
+        :ios => "10.0",
+        :osx => "10.12"
     }
-    s.ios.deployment_target = "9.0"
-    s.osx.deployment_target = "10.11"
+    s.ios.deployment_target = "10.0"
+    s.osx.deployment_target = "10.12"
 
     s.homepage      = "https://github.com/okta/okta-mobile-swift"
     s.license       = { :type => "APACHE2", :file => "LICENSE" }
@@ -19,7 +19,7 @@ Authenticate users using web-based OIDC.
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/WebAuthenticationUI/**/*.swift"
     s.resources     = "Sources/WebAuthenticationUI/Resources/*.lproj"
-    s.swift_version = "5.5"
+    s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"
     s.dependency "OktaOAuth2", "#{s.version.to_s}"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,10 +7,10 @@ var package = Package(
     name: "AuthFoundation",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v10),
         .tvOS(.v10),
         .watchOS(.v7),
-        .macOS(.v10_11),
+        .macOS(.v10_12),
         .macCatalyst(.v13)
     ],
     products: [
@@ -20,6 +20,7 @@ var package = Package(
         .library(name: "WebAuthenticationUI", targets: ["WebAuthenticationUI"])
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
     ],
     targets: [
         .target(name: "AuthFoundation",
@@ -59,7 +60,3 @@ var package = Package(
     ],
     swiftLanguageVersions: [.v5]
 )
-
-#if swift(>=5.6)
-    package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
-#endif

--- a/README.md
+++ b/README.md
@@ -384,11 +384,11 @@ Only the last 4 major platform versions are officially supported, unless there a
 
 | Platform    | Supported | Best-Effort |
 | ----------- | --------- | ----------- |
-| iOS         | 12.0      | 9.0         |
+| iOS         | 12.0      | 10.0        |
 | tvOS        | 12.0      | 10.0        |
 | watchOS     | 8.0       | 7.0         |
 | macCatalyst | 13.0      | 13.0        |
-| macOS       | 12.0      | 10.11       |
+| macOS       | 12.0      | 10.12       |
 
 Once a platform version becomes unsupported, dropping support for it will not be considered a breaking change and will be done in a minor release. For example, iOS 12 will cease to be supported when iOS 16 gets released, and might be dropped in a minor release.
 

--- a/Samples/UserPasswordSignIn/UserPasswordSignIn (macOS)/main.swift
+++ b/Samples/UserPasswordSignIn/UserPasswordSignIn (macOS)/main.swift
@@ -14,11 +14,7 @@ import Foundation
 import ArgumentParser
 import OktaOAuth2
 
-#if swift(>=5.6)
 typealias Command = AsyncParsableCommand
-#else
-typealias Command = ParsableCommand
-#endif
 
 @main
 struct UserPasswordSignIn: Command {
@@ -37,7 +33,6 @@ struct UserPasswordSignIn: Command {
     @Option(help: "Password")
     var password: String?
     
-    #if swift(>=5.6)
     mutating func run() async throws {
         guard #available(macOS 12, *) else {
             print("'user-password-sign-in' isn't supported on this platform.")
@@ -49,28 +44,4 @@ struct UserPasswordSignIn: Command {
                                          password: try promptPassword())
         printUserInfo(using: token)
     }
-    #else
-    mutating func run() throws {
-        guard #available(macOS 12, *) else {
-            print("'user-password-sign-in' isn't supported on this platform.")
-            return
-        }
- 
-        let flow = try createFlow()
-        
-        let group = DispatchGroup()
-        group.enter()
-        flow.start(username: try promptUsername(),
-                   password: try promptPassword()) { result in
-            defer { group.leave() }
-            switch result {
-            case .success(let token):
-                printUserInfo(using: token)
-            case .failure(let error):
-                print(error)
-            }
-        }
-        _ = group.wait(timeout: .now() + 30)
-    }
-    #endif
 }

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -359,7 +359,7 @@ public class WebAuthentication {
                                           delegate: delegate)
         }
         
-        if #available(iOS 9.0, *) {
+        if #available(iOS 10.0, *) {
             return SafariBrowserProvider(loginFlow: loginFlow,
                                          logoutFlow: logoutFlow,
                                          from: window,

--- a/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/WebAuthenticationUI.md
+++ b/Sources/WebAuthenticationUI/WebAuthenticationUI.docc/WebAuthenticationUI.md
@@ -17,7 +17,7 @@ To maximize the number of platforms and OS versions your application can support
 
 Platform | Versions | Authentication Controller |
 ---|---|---
-iOS | 9.0 - 10.x | SFSafariViewController 
+iOS | 10.0 - 10.x | SFSafariViewController 
 iOS | 11.0 | SFAuthenticationSession 
 iOS | 12.0 - Current | ASWebAuthenticationSession 
 macOS | 10.15 - Current | ASWebAuthenticationSession


### PR DESCRIPTION
This required dropping support for iOS 9 and macOS 10.11, but due to [our stated support policy](https://github.com/okta/okta-mobile-swift?tab=readme-ov-file#platforms), these were considered supported in a best-effort capacity, so dropping them does not constitute a breaking release.