### PR TITLE
Add SDK Privacy Manifests

### DIFF
--- a/OktaAuthFoundation.podspec
+++ b/OktaAuthFoundation.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaAuthFoundation"
     s.module_name      = "AuthFoundation"
-    s.version          = "1.7.0"
+    s.version          = "1.7.1"
     s.summary          = "Okta Authentication Foundation"
     s.description      = <<-DESC
 Provides the foundation and common features used to authenticate users, managing the lifecycle and storage of tokens and credentials, and provide a base for other Okta SDKs to build upon.
@@ -22,6 +22,6 @@ Provides the foundation and common features used to authenticate users, managing
     s.authors       = { "Okta Developers" => "developer@okta.com"}
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/AuthFoundation/**/*.swift"
-    s.resources     = "Sources/AuthFoundation/Resources/*.lproj"
+    s.resources     = "Sources/AuthFoundation/Resources/**/*"
     s.swift_version = "5.6"
 end

--- a/OktaDirectAuth.podspec
+++ b/OktaDirectAuth.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaDirectAuth"
-    s.version          = "1.7.0"
+    s.version          = "1.7.1"
     s.summary          = "Okta Direct Authentication"
     s.description      = <<-DESC
 Enables application developers to build native sign in experiences using the Okta Direct Authentication API.
@@ -21,7 +21,7 @@ Enables application developers to build native sign in experiences using the Okt
     s.authors       = { "Okta Developers" => "developer@okta.com"}
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/OktaDirectAuth/**/*.swift"
-    s.resources     = "Sources/OktaDirectAuth/Resources/*.lproj"
+    s.resources     = "Sources/OktaDirectAuth/Resources/**/*"
     s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"

--- a/OktaOAuth2.podspec
+++ b/OktaOAuth2.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "OktaOAuth2"
-    s.version          = "1.7.0"
+    s.version          = "1.7.1"
     s.summary          = "Okta OAuth2 Authentication"
     s.description      = <<-DESC
 Enables application developers to authenticate users utilizing a variety of OAuth2 authentication flows.
@@ -21,7 +21,7 @@ Enables application developers to authenticate users utilizing a variety of OAut
     s.authors       = { "Okta Developers" => "developer@okta.com"}
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/OktaOAuth2/**/*.swift"
-    s.resources     = "Sources/OktaOAuth2/Resources/*.lproj"
+    s.resources     = "Sources/OktaOAuth2/Resources/**/*"
     s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"

--- a/OktaWebAuthenticationUI.podspec
+++ b/OktaWebAuthenticationUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name             = "OktaWebAuthenticationUI"
     s.module_name      = "WebAuthenticationUI"
-    s.version          = "1.7.0"
+    s.version          = "1.7.1"
     s.summary          = "Okta Web Authentication UI"
     s.description      = <<-DESC
 Authenticate users using web-based OIDC.
@@ -18,7 +18,7 @@ Authenticate users using web-based OIDC.
     s.authors       = { "Okta Developers" => "developer@okta.com"}
     s.source        = { :git => "https://github.com/okta/okta-mobile-swift.git", :tag => s.version.to_s }
     s.source_files  = "Sources/WebAuthenticationUI/**/*.swift"
-    s.resources     = "Sources/WebAuthenticationUI/Resources/*.lproj"
+    s.resources     = "Sources/WebAuthenticationUI/Resources/**/*"
     s.swift_version = "5.6"
 
     s.dependency "OktaAuthFoundation", "#{s.version.to_s}"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 
 | Version | Status                             |
 | ------- | ---------------------------------- |
-| 1.7.0   | ✔️ Stable                             |
+| 1.7.1   | ✔️ Stable                             |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/AuthFoundation/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/AuthFoundation/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/UserDefaultsTokenStorage.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 #if canImport(LocalAuthentication) && !os(tvOS)
 import LocalAuthentication
 #else
@@ -160,3 +161,4 @@ final class UserDefaultsTokenStorage: TokenStorage {
         userDefaults.synchronize()
     }
 }
+#endif

--- a/Sources/AuthFoundation/Version.swift
+++ b/Sources/AuthFoundation/Version.swift
@@ -13,5 +13,5 @@
 import Foundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.7.0")
+public let Version = SDKVersion(sdk: "okta-authfoundation-swift", version: "1.7.1")
 // swiftlint:enable identifier_name

--- a/Sources/OktaDirectAuth/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/OktaDirectAuth/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/OktaDirectAuth/Version.swift
+++ b/Sources/OktaDirectAuth/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "1.7.0")
+public let Version = SDKVersion(sdk: "okta-directauth-swift", version: "1.7.1")
 // swiftlint:enable identifier_name

--- a/Sources/OktaOAuth2/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/OktaOAuth2/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/OktaOAuth2/Version.swift
+++ b/Sources/OktaOAuth2/Version.swift
@@ -13,5 +13,5 @@
 @_exported import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.7.0")
+public let Version = SDKVersion(sdk: "okta-oauth2-swift", version: "1.7.1")
 // swiftlint:enable identifier_name

--- a/Sources/WebAuthenticationUI/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/WebAuthenticationUI/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/Sources/WebAuthenticationUI/Version.swift
+++ b/Sources/WebAuthenticationUI/Version.swift
@@ -14,5 +14,5 @@ import Foundation
 import AuthFoundation
 
 // swiftlint:disable identifier_name
-public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.7.0")
+public let Version = SDKVersion(sdk: "okta-webauthenticationui-swift", version: "1.7.1")
 // swiftlint:enable identifier_name

--- a/Tests/AuthFoundationTests/UserDefaultsTokenStorageTests.swift
+++ b/Tests/AuthFoundationTests/UserDefaultsTokenStorageTests.swift
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and limitations under the License.
 //
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import XCTest
 @testable import AuthFoundation
 import TestCommon
@@ -102,3 +103,4 @@ final class UserDefaultTokenStorageTests: XCTestCase {
         XCTAssertNil(storage.defaultTokenID)
     }
 }
+#endif


### PR DESCRIPTION
*Note:* The only use of the `UserDefaults` APIs are for platforms that do not support the keychain (e.g. Linux), so these classes have been `#ifdef`'d out to prevent these symbols being referenced on Apple platforms.