### PR TITLE
EdDSA in openid-configuration support

### DIFF
--- a/Sources/AuthFoundation/JWT/Enums/JWK+Enums.swift
+++ b/Sources/AuthFoundation/JWT/Enums/JWK+Enums.swift
@@ -62,6 +62,8 @@ extension JWK {
         case pbes2_HS256_A128KW = "PBES2-HS256+A128KW"
         case pbes2_HS384_A192KW = "PBES2-HS384+A192KW"
         case pbes2_HS512_A256KW = "PBES2-HS512+A256KW"
+
+        case EdDSA = "EdDSA"
     }
     // swiftlint:enable identifier_name
 }


### PR DESCRIPTION
Added EdDSA case to support openid-configuration where EdDSA presented in "id_token_signing_alg_values_supported" field.