### PR TITLE
Allows Keychain read failures to be ignored

### DIFF
--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -80,12 +80,10 @@ final class CredentialCoordinatorImpl: CredentialCoordinator {
               prompt: String? = nil,
               authenticationContext: TokenAuthenticationContext? = nil) throws -> [Credential]
     {
-        try allIDs
-            .map(tokenStorage.metadata(for:))
+         allIDs
+            .compactMap { try? tokenStorage.metadata(for: $0) } 
             .filter(expression)
-            .compactMap({ metadata in
-                try? self.with(id: metadata.id, prompt: prompt, authenticationContext: authenticationContext)
-            })
+            .compactMap { try? self.with(id: $0.id, prompt: prompt, authenticationContext: authenticationContext) }
     }
     
     func remove(credential: Credential) throws {

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -80,7 +80,7 @@ final class CredentialCoordinatorImpl: CredentialCoordinator {
               prompt: String? = nil,
               authenticationContext: TokenAuthenticationContext? = nil) throws -> [Credential]
     {
-         allIDs
+        allIDs
             .compactMap { try? tokenStorage.metadata(for: $0) } 
             .filter(expression)
             .compactMap { try? self.with(id: $0.id, prompt: prompt, authenticationContext: authenticationContext) }


### PR DESCRIPTION
Alleviates invalid state for the user created by bug #198.

This allows failing queries into storage (Keychain) to be ignored, for the purpose of allowing `Credential.find` calls to provide as many valid `Credential`s as it can without it being short-circuited on a single failure. 

If the metadata or the item itself is not found in storage, we can disregard the entire `Credential` instead of throwing an error for the entire query. This allows applications to query for a `Credential`, even if the persistence layer has an invalid state for any given `Credential`. 