### PR TITLE
Ensure token item and metadata keychain accessibility settings are consistent.

### DIFF
--- a/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
@@ -99,7 +99,7 @@ final class KeychainTokenStorage: TokenStorage {
                                  value: data)
         
         let metadataAccessibility: Keychain.Accessibility
-        if (accessibility.isSynchronizable) {
+        if accessibility.isSynchronizable {
             metadataAccessibility = .afterFirstUnlock
         } else {
             metadataAccessibility = .afterFirstUnlockThisDeviceOnly

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -26,7 +26,7 @@ public final class Token: Codable, Equatable, Hashable, Expires {
     /// The unique identifier for this token.
     public internal(set) var id: String
     
-    // The date this token was issued at.
+    /// The date this token was issued at.
     public let issuedAt: Date?
     
     /// The string type of the token (e.g. `Bearer`).

--- a/Sources/AuthFoundation/User Management/CredentialSecurity.swift
+++ b/Sources/AuthFoundation/User Management/CredentialSecurity.swift
@@ -46,6 +46,9 @@ extension Credential {
         ///
         /// If you wish to change the default security threshold for Keychain items, you can assign a new value here. Additionally, if a ``context(_:)`` value is assigned to the ``standard`` property, that context will be used when fetching credentials unless otherwise specified.
         public static var standard: [Security] = [.accessibility(.afterFirstUnlockThisDeviceOnly)]
+        
+        /// Determines whether or not the ``Credential/default`` setting is synchronized across a user's devices using iCloud Keychain.
+        public static var isDefaultSynchronizable: Bool = false
         #else
         public static var standard: [Security] = []
         #endif


### PR DESCRIPTION
This addresses #198 by:

1. Ensuring the token metadata is stored with the appropriate accessibility settings, respecting the parent item's iCloud sync setting.
2. Returning token IDs only if both their item and metadata keychain entries can be found.
3. Establishing the `Credential.Security.isDefaultSynchronizable` property, allowing the default identifier to be shared.

This also adds unit test coverage to validate these changes.