### PR TITLE
Report any errors that occur during interactions with Credential.default

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ on:
       - 'Tests/**/*.swift'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
   NSUnbufferedIO: YES 
 
 jobs:
@@ -71,6 +71,7 @@ jobs:
         destination:
         - "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro Max"
         - "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro Max"
+        - "platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max"
         - "platform=tvOS Simulator,OS=17.5,name=Apple TV"
         - "platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro"
         - "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 7 (45mm)"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,6 @@ on:
       - 'Tests/**/*.swift'
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
   NSUnbufferedIO: YES 
 
 jobs:
@@ -51,6 +50,8 @@ jobs:
     timeout-minutes: 10
     needs:
       - SwiftBuild
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
     steps:
     - uses: actions/checkout@master
     - name: OktaAuthFoundation.podspec
@@ -77,6 +78,8 @@ jobs:
         - "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 7 (45mm)"
         - "platform=macOS,name=My Mac"
     timeout-minutes: 25
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
     steps:
     - name: Set test variables
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ on:
       - 'Tests/**/*.swift'
 
 env:
+  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
   NSUnbufferedIO: YES 
 
 jobs:
@@ -50,8 +51,6 @@ jobs:
     timeout-minutes: 10
     needs:
       - SwiftBuild
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
     steps:
     - uses: actions/checkout@master
     - name: OktaAuthFoundation.podspec
@@ -72,14 +71,11 @@ jobs:
         destination:
         - "platform=iOS Simulator,OS=16.4,name=iPhone 14 Pro Max"
         - "platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro Max"
-        - "platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max"
         - "platform=tvOS Simulator,OS=17.5,name=Apple TV"
         - "platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro"
         - "platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 7 (45mm)"
         - "platform=macOS,name=My Mac"
     timeout-minutes: 25
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
     steps:
     - name: Set test variables
       run: |

--- a/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
+++ b/Sources/AuthFoundation/Token Management/Internal/KeychainTokenStorage.swift
@@ -26,15 +26,21 @@ final class KeychainTokenStorage: TokenStorage {
     weak var delegate: TokenStorageDelegate?
     
     private(set) lazy var defaultTokenID: String? = {
-        guard let defaultResult = try? Keychain
+        do {
+            let defaultResult = try Keychain
                 .Search(account: KeychainTokenStorage.defaultTokenName)
-                .get(),
-              let id = String(data: defaultResult.value, encoding: .utf8)
-        else {
+                .get()
+            guard let id = String(data: defaultResult.value, encoding: .utf8)
+            else {
+                return nil
+            }
+            
+            return id
+        } catch {
+            NSLog("Unexpected error while loading the default token ID from the keychain: %@", error.localizedDescription)
+            NotificationCenter.default.post(name: .credentialDefaultError, object: error)
             return nil
         }
-        
-        return id
     }()
 
     func setDefaultTokenID(_ id: String?) throws {

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -36,6 +36,9 @@ extension Notification.Name {
 
     /// Notification broadcast when a credential fails to refresh.
     public static let credentialRefreshFailed = Notification.Name("com.okta.credential.refresh.failed")
+    
+    /// Notification broadcast when an internal error occurs with the default credential static member.
+    public static let credentialDefaultError = Notification.Name("com.okta.credential.default.error")
 }
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)

--- a/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
+++ b/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
@@ -73,7 +73,18 @@ final class UserCoordinatorTests: XCTestCase {
         XCTAssertEqual(try coordinator.with(id: token.id, prompt: nil, authenticationContext: nil), credential)
     }
     
+    func testDirectAssignmentToCredentialDefault() throws {
+        XCTAssertNil(coordinator.default)
+        let token = Token.simpleMockToken
+        coordinator.default = try coordinator.store(token: token, tags: [:], security: Credential.Security.standard)
+        XCTAssertNotNil(coordinator.default)
+        XCTAssertEqual(coordinator.default?.id, token.id)
+    }
+    
     func testImplicitCredentialForToken() throws {
+        XCTAssertTrue(storage.allIDs.isEmpty)
+        XCTAssertNil(coordinator.default)
+        
         let credential = try coordinator.store(token: token, tags: [:], security: [])
         
         XCTAssertEqual(storage.allIDs, [token.id])
@@ -81,7 +92,7 @@ final class UserCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.default, credential)
     }
     
-    func testNotifications() throws {
+    func testCredentialChangedNotification() throws {
         let oldCredential = coordinator.default
         
         let recorder = NotificationRecorder(observing: [.defaultCredentialChanged])


### PR DESCRIPTION
While rare, there is the possibility that errors may be thrown while assigning a credential to `Credential.default`. Since those functions are accessed behind a property setter/getter, they aren't accessible to the developer.

In that case, this update introduces a notification that can be observed, as well as NSLog reporting, of those errors for traceability.