### PR TITLE
Change `scope` to be an array of strings for developer convenience and consistency

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,6 @@ only_rules:
   - operator_usage_whitespace
   - return_arrow_whitespace
   - trailing_whitespace
-  - attributes
  
   # Empty
   - empty_collection_literal

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
@@ -25,7 +25,7 @@ class SignInViewController: UIHostingController<SignInView> {
         {
             configuration.scope.remove(at: index)
             
-            flow = DirectAuthenticationFlow(client: OAuth2Client(configuration))
+            flow = try? DirectAuthenticationFlow(client: OAuth2Client(configuration))
         } else {
             flow = try? DirectAuthenticationFlow()
         }

--- a/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
+++ b/Samples/DirectAuthSignIn/DirectAuthSignIn/SignInViewController.swift
@@ -20,15 +20,12 @@ class SignInViewController: UIHostingController<SignInView> {
         let flow: DirectAuthenticationFlow?
         
         // Workaround to remove the `device_sso` scope, when included in the property list.
-        if let configuration = try? OAuth2Client.PropertyListConfiguration(),
-           let ssoRange = configuration.scope.range(of: "device_sso")
+        if var configuration = try? OAuth2Client.PropertyListConfiguration(),
+           let index = configuration.scope.firstIndex(of: "device_sso")
         {
-            var scope = configuration.scope
-            scope.removeSubrange(ssoRange)
+            configuration.scope.remove(at: index)
             
-            flow = DirectAuthenticationFlow(issuerURL: configuration.issuerURL,
-                                            clientId: configuration.clientId,
-                                            scope: scope)
+            flow = DirectAuthenticationFlow(client: OAuth2Client(configuration))
         } else {
             flow = try? DirectAuthenticationFlow()
         }

--- a/Samples/JWTSignIn/JWTSignIn/JWTSignin.swift
+++ b/Samples/JWTSignIn/JWTSignIn/JWTSignin.swift
@@ -25,7 +25,7 @@ struct JWTSignin: AsyncParsableCommand {
     var clientId: String
     
     @Option(name: [.long, .short], help: "The scopes to use.")
-    var scope: String = "openid profile"
+    var scope: [String] = ["openid", "profile"]
     
     @Option(
         name: [.long, .short],

--- a/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
@@ -98,7 +98,7 @@ class TokenDetailViewController: UIViewController {
         
         let string = NSMutableAttributedString()
         addString(to: string, title: "Expires in", value: "\(token.expiresIn) seconds")
-        addString(to: string, title: "Scope", value: token.$scope.rawValue ?? "N/A")
+        addString(to: string, title: "Scope", value: token.scope?.joined(separator: " ") ?? "N/A")
         addString(to: string, title: "Token type", value: token.tokenType)
         
         addString(to: string, title: "Access token", value: token.accessToken)

--- a/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
+++ b/Samples/Shared/Common/ViewControllers/TokenDetailViewController.swift
@@ -98,7 +98,7 @@ class TokenDetailViewController: UIViewController {
         
         let string = NSMutableAttributedString()
         addString(to: string, title: "Expires in", value: "\(token.expiresIn) seconds")
-        addString(to: string, title: "Scope", value: token.scope ?? "N/A")
+        addString(to: string, title: "Scope", value: token.$scope.rawValue ?? "N/A")
         addString(to: string, title: "Token type", value: token.tokenType)
         
         addString(to: string, title: "Access token", value: token.accessToken)

--- a/Sources/AuthFoundation/AuthFoundation.docc/AuthFoundation.md
+++ b/Sources/AuthFoundation/AuthFoundation.docc/AuthFoundation.md
@@ -32,7 +32,9 @@ You can use AuthFoundation when you want to:
 - ``OpenIdConfiguration``
 - ``AuthenticationMethod``
 - ``AuthenticationFlow``
+- ``AuthenticationContext``
 - ``AuthenticationDelegate``
+- ``StandardAuthenticationContext``
 - ``OAuth2TokenRequest``
 - ``GrantType``
 - ``PKCE``
@@ -45,7 +47,7 @@ You can use AuthFoundation when you want to:
 - ``JWKS``
 - ``JWTClaim``
 - ``HasClaims``
-- ``Claim``
+- ``ClaimCollection``
 - ``JSONClaimContainer``
 - ``JSON``
 - ``AnyJSON``
@@ -92,6 +94,9 @@ You can use AuthFoundation when you want to:
 - ``Empty``
 - ``JSONDecodable``
 - ``OAuth2APIRequest``
+- ``OAuth2APIRequestCategory``
+- ``AuthenticationFlowRequest``
+- ``ProvidesOAuth2Parameters``
 
 ### Error Types
 

--- a/Sources/AuthFoundation/Deprecations/OAuth2Client+Deprecations.swift
+++ b/Sources/AuthFoundation/Deprecations/OAuth2Client+Deprecations.swift
@@ -21,11 +21,11 @@ extension OAuth2Client {
                             authentication: ClientAuthentication = .none,
                             session: URLSessionProtocol? = nil) throws
     {
-        try self.init(domain: domain,
-                      clientId: clientId,
-                      scope: scopes,
-                      authentication: authentication,
-                      session: session)
+        self.init(try Configuration(domain: domain,
+                                    clientId: clientId,
+                                    scope: scopes,
+                                    authentication: authentication),
+                  session: session)
     }
     
     @_documentation(visibility: private)
@@ -36,10 +36,10 @@ extension OAuth2Client {
                             authentication: ClientAuthentication = .none,
                             session: URLSessionProtocol? = nil)
     {
-        self.init(issuerURL: baseURL,
-                  clientId: clientId,
-                  scope: scopes,
-                  authentication: authentication,
+        self.init(Configuration(issuerURL: baseURL,
+                                clientId: clientId,
+                                scope: scopes,
+                                authentication: authentication),
                   session: session)
     }
 }

--- a/Sources/AuthFoundation/JWT/Enums/JWTClaim.swift
+++ b/Sources/AuthFoundation/JWT/Enums/JWTClaim.swift
@@ -354,7 +354,7 @@ public extension HasClaims where ClaimType == JWTClaim {
     /// Returns the Authentication Context Class Reference for this token.
     var authenticationClassReference: [String]? {
         let value: String? = value(for: .authContextClassReference)
-        return value?.components(separatedBy: .whitespaces)
+        return value?.whitespaceSeparated
     }
     
     /// The list of authentication methods included in this token, which defines the list of methods that were used to authenticate the user.

--- a/Sources/AuthFoundation/JWT/Extensions/Claim+ValueExtensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/Claim+ValueExtensions.swift
@@ -54,9 +54,18 @@ public extension HasClaims {
 /// Extension which introduces array-value conversion functions for ``ClaimConvertable`` types.
 public extension HasClaims {
     /// Returns the value for the given key as an array of values converted using a``ClaimConvertable`` type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     /// - Parameter key: String payload key name.
     /// - Returns: Value converted to an array of the requested type.
     func value<T: ClaimConvertable>(for key: String) throws -> [T] {
+        if T.self == String.self,
+           let value = payload[key] as? String,
+           let result = value.components(separatedBy: .whitespaces) as? [T]
+        {
+            return result
+        }
+
         guard let array = payload[key] as? [ClaimConvertable]
         else {
             throw ClaimError.missingRequiredValue(key: key)
@@ -66,6 +75,8 @@ public extension HasClaims {
     }
     
     /// Returns the value for the given key as an array of values converted using a``ClaimConvertable`` type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     /// - Parameter claim: The claim type to retrieve.
     /// - Returns: Value converted to an array of the requested type.
     func value<T: ClaimConvertable>(for claim: ClaimType) throws -> [T] {
@@ -73,14 +84,24 @@ public extension HasClaims {
     }
     
     /// Returns the optional value for the given key as an array of values converted using a``ClaimConvertable`` type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     /// - Parameter key: String payload key name.
     /// - Returns: Optional value converted to an array of the requested type.
     func value<T: ClaimConvertable>(for key: String) -> [T]? {
+        if T.self == String.self,
+           let value = payload[key] as? String
+        {
+            return value.components(separatedBy: .whitespaces) as? [T]
+        }
+        
         let array = payload[key] as? [ClaimConvertable]
         return array?.compactMap { T.convert(from: $0) }
     }
 
     /// Returns the optional value for the given key as an array of values converted using a``ClaimConvertable`` type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     /// - Parameter claim: The claim type to retrieve.
     /// - Returns: Optional value converted to an array of the requested type.
     func value<T: ClaimConvertable>(for claim: ClaimType) -> [T]? {
@@ -141,11 +162,15 @@ public extension HasClaims {
 /// Extension which introduces array-value subscript conversion functions for ``ClaimConvertable`` types.
 public extension HasClaims {
     /// Return the given claim's value, defined with the given enum value, as the expectred ``ClaimConvertable``value type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     subscript<T: ClaimConvertable>(_ claim: ClaimType) -> [T]? {
         value(for: claim)
     }
     
     /// Return the given claim's value, defined with the given enum value, as the expectred ``ClaimConvertable``value type.
+    ///
+    /// > Note: If the underlying payload value is a String, and the result type is expected to be a String array `[String]`, this function will automatically split the value by whitespaces.
     subscript<T: ClaimConvertable>(_ key: String) -> [T]? {
         value(for: key)
     }

--- a/Sources/AuthFoundation/JWT/Extensions/Claim+ValueExtensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/Claim+ValueExtensions.swift
@@ -61,7 +61,7 @@ public extension HasClaims {
     func value<T: ClaimConvertable>(for key: String) throws -> [T] {
         if T.self == String.self,
            let value = payload[key] as? String,
-           let result = value.components(separatedBy: .whitespaces) as? [T]
+           let result = value.whitespaceSeparated as? [T]
         {
             return result
         }
@@ -92,7 +92,7 @@ public extension HasClaims {
         if T.self == String.self,
            let value = payload[key] as? String
         {
-            return value.components(separatedBy: .whitespaces) as? [T]
+            return value.whitespaceSeparated as? [T]
         }
         
         let array = payload[key] as? [ClaimConvertable]

--- a/Sources/AuthFoundation/JWT/Extensions/ClaimConvertable+Extensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/ClaimConvertable+Extensions.swift
@@ -28,10 +28,33 @@ extension Double: ClaimConvertable {}
 extension Float: ClaimConvertable {}
 
 @_documentation(visibility: private)
-extension URL: ClaimConvertable {}
+extension URL: ClaimConvertable {
+    public static func convert(from value: Any?) -> Self? {
+        guard let string = value as? String else { return nil }
+        return URL(string: string)
+    }
+}
 
 @_documentation(visibility: private)
-extension Date: ClaimConvertable {}
+extension Date: ClaimConvertable {
+    public static func convert(from value: Any?) -> Self? {
+        if let time = value as? Int {
+            return Date(timeIntervalSince1970: TimeInterval(time))
+        }
+        
+        if let time = value as? String {
+            if let date = ISO8601DateFormatter().date(from: time) {
+                return date
+            }
+            
+            if let date = httpDateFormatter.date(from: time) {
+                return date
+            }
+        }
+        
+        return nil
+    }
+}
 
 @_documentation(visibility: private)
 extension JWTClaim: ClaimConvertable {}
@@ -44,29 +67,6 @@ extension NSString: ClaimConvertable {}
 
 @_documentation(visibility: private)
 extension NSNumber: ClaimConvertable {}
-
-@_documentation(visibility: private)
-extension ClaimConvertable where Self == Date {
-    public static func convert(from value: Any?) -> Self? {
-        if let time = value as? Int {
-            return Date(timeIntervalSince1970: TimeInterval(time))
-        }
-        
-        if let time = value as? String {
-            return ISO8601DateFormatter().date(from: time)
-        }
-        
-        return nil
-    }
-}
-
-@_documentation(visibility: private)
-extension ClaimConvertable where Self == URL {
-    public static func convert(from value: Any?) -> Self? {
-        guard let string = value as? String else { return nil }
-        return URL(string: string)
-    }
-}
 
 @_documentation(visibility: private)
 extension ClaimConvertable where Self: RawRepresentable {

--- a/Sources/AuthFoundation/JWT/Extensions/ClaimConvertable+Extensions.swift
+++ b/Sources/AuthFoundation/JWT/Extensions/ClaimConvertable+Extensions.swift
@@ -28,6 +28,18 @@ extension Double: ClaimConvertable {}
 extension Float: ClaimConvertable {}
 
 @_documentation(visibility: private)
+extension JWTClaim: ClaimConvertable {}
+
+@_documentation(visibility: private)
+extension GrantType: ClaimConvertable {}
+
+@_documentation(visibility: private)
+extension NSString: ClaimConvertable {}
+
+@_documentation(visibility: private)
+extension NSNumber: ClaimConvertable {}
+
+@_documentation(visibility: private)
 extension URL: ClaimConvertable {
     public static func convert(from value: Any?) -> Self? {
         guard let string = value as? String else { return nil }
@@ -55,18 +67,6 @@ extension Date: ClaimConvertable {
         return nil
     }
 }
-
-@_documentation(visibility: private)
-extension JWTClaim: ClaimConvertable {}
-
-@_documentation(visibility: private)
-extension GrantType: ClaimConvertable {}
-
-@_documentation(visibility: private)
-extension NSString: ClaimConvertable {}
-
-@_documentation(visibility: private)
-extension NSNumber: ClaimConvertable {}
 
 @_documentation(visibility: private)
 extension ClaimConvertable where Self: RawRepresentable {

--- a/Sources/AuthFoundation/JWT/JWT.swift
+++ b/Sources/AuthFoundation/JWT/JWT.swift
@@ -27,7 +27,7 @@ public struct JWT: RawRepresentable, Codable, HasClaims, Expires {
     public var issuer: String? { self[.issuer] }
     
     /// The intended audience for this token.
-    public var audience: [String]? { self[.audience] }
+    public var audience: String? { self[.audience] }
     
     /// The date this token was issued.
     public var issuedAt: Date? { self[.issuedAt] }

--- a/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
+++ b/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
@@ -1,0 +1,218 @@
+//
+// Copyright (c) 2024-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Defines a type of collection which can be
+@_documentation(visibility: internal)
+public protocol ClaimCollectionContainer {
+    associatedtype Element: ClaimConvertable & APIRequestArgument
+    associatedtype RawValue
+    
+    var array: [Element] { get set }
+    var isNil: Bool { get }
+    
+    init(container elements: [Element]?)
+}
+
+@_documentation(visibility: internal)
+extension Array: ClaimCollectionContainer where Element: ClaimConvertable & APIRequestArgument {
+    public typealias RawValue = String
+    
+    public var array: [Element] {
+        get { self }
+        set { self = newValue }
+    }
+    
+    public var isNil: Bool { false }
+    
+    public init(container elements: [Element]?) {
+        self.init(elements ?? [])
+    }
+}
+
+@_documentation(visibility: internal)
+extension Optional: ClaimCollectionContainer where Wrapped: ClaimCollectionContainer {
+    public typealias Element = Wrapped.Element
+    public typealias RawValue = String?
+
+    public var array: [Element] {
+        get {
+            switch self {
+            case .none:
+                return []
+            case .some(let wrapped):
+                return wrapped.array
+            }
+        }
+        
+        set {
+            if let newValue = newValue as? Wrapped {
+                self = .some(newValue)
+            } else {
+                self = .none
+            }
+        }
+    }
+    
+    public var isNil: Bool {
+        switch self {
+        case .none:
+            return true
+        case .some:
+            return false
+        }
+    }
+    
+    public init(container elements: [Element]?) {
+        if let elements = elements {
+            self = .some(Wrapped(container: elements))
+        } else {
+            self = .none
+        }
+    }
+}
+
+/// Indicates a special type of claim whose value is interchangable between a whitespace-separated value, or an array of values.
+///
+/// This is used to simplify interactions with Claim values whose raw representation is the claim's string value, separated by whitespace. This enables the conversion between the string representation, as sent to/received from the server, and the array of claims which it represents.
+///
+/// The ``rawValue`` of the collection returns the whitespace-separated string representation of the value this wrapper contains, which can be accessed using the projected value of the property. For example:
+///
+/// ```
+/// config.scope.append("profile")
+/// print(config.$scope.rawValue)
+/// ```
+@propertyWrapper
+public struct ClaimCollection<Container: ClaimCollectionContainer> {
+    /// The array representation of the claims in this list.
+    public var wrappedValue: Container
+    
+    /// Provides access to the property wrapper.
+    public var projectedValue: Self { self }
+    
+    /// Initializer using the array representation of this value.
+    /// - Parameter wrappedValue: Array of claim values.
+    public init(wrappedValue: Container) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension ClaimCollection: APIRequestArgument where Container.RawValue == String {
+    @_documentation(visibility: internal)
+    public var stringValue: Container.RawValue {
+        rawValue
+    }
+}
+
+extension ClaimCollection: ExpressibleByArrayLiteral {
+    /// Initializer using an array literal representation of values.
+    ///
+    /// This simplifies the creation of a claim list wrapper from a raw array literal of values.
+    /// - Parameter elements: List of claim values.
+    public init(arrayLiteral elements: Container.Element ...) {
+        self.wrappedValue = Container(container: elements)
+    }
+}
+
+@_documentation(visibility: internal)
+extension ClaimCollection: ExpressibleByNilLiteral where Container: ExpressibleByNilLiteral {
+    @_documentation(visibility: internal)
+    public init(nilLiteral: ()) {
+        self.wrappedValue = .init(container: nil)
+    }
+    
+    @_documentation(visibility: internal)
+    public var isNil: Bool {
+        wrappedValue.isNil
+    }
+}
+
+extension ClaimCollection: RawRepresentable {
+    public typealias RawValue = Container.RawValue
+    
+    /// The whitespace-separated string representation of the values in this claim list.
+    ///
+    /// It is recommended that this property be used when representing this list of claims when sending the value to a server.
+    public var rawValue: RawValue {
+        if wrappedValue.isNil {
+            return (nil as String?) as! RawValue
+        }
+        
+        return wrappedValue
+            .array
+            .compactMap { $0.stringValue }
+            .joined(separator: " ") as! RawValue
+    }
+    
+    /// Initializer accepting a whitespace-separated string representation of the value.
+    /// - Parameter value: Whitespace-separated string.
+    public init(wrappedValue value: String) {
+        self.wrappedValue = Container(container: value.whitespaceSeparated.compactMap(Container.Element.convert(from:)))
+    }
+}
+
+extension ClaimCollection where Container.RawValue == String? {
+    public init(rawValue value: String?) {
+        if let value = value {
+            self.wrappedValue = Container(container: value.whitespaceSeparated.compactMap(Container.Element.convert(from:)))
+        } else {
+            self.wrappedValue = .init(container: nil)
+        }
+    }
+}
+
+extension ClaimCollection where Container.RawValue == String {
+    public init(rawValue value: String) {
+        self.init(wrappedValue: value)
+    }
+}
+
+extension ClaimCollection {
+    public init(rawValue: Container.RawValue) {
+        if Container.self is ExpressibleByNilLiteral {
+            self.wrappedValue = Optional<Container>.none!
+        } else {
+            self.wrappedValue = Container(container: [])
+        }
+    }
+}
+
+extension ClaimCollection: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(wrappedValue: value)
+    }
+}
+
+extension ClaimCollection: ExpressibleByExtendedGraphemeClusterLiteral {
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(wrappedValue: value)
+    }
+}
+
+extension ClaimCollection: ExpressibleByUnicodeScalarLiteral {
+    public init(unicodeScalarLiteral value: String) {
+        self.init(wrappedValue: value)
+    }
+}
+
+extension ClaimCollection: Hashable where Container.Element: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue.array)
+    }
+}
+
+extension ClaimCollection: Equatable where Container.Element: Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.wrappedValue.array == rhs.wrappedValue.array
+    }
+}

--- a/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
+++ b/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
@@ -82,6 +82,28 @@ extension Optional: ClaimCollectionContainer where Wrapped: ClaimCollectionConta
     }
 }
 
+/// Represents a type which can contain a whitespace-separated array of string values.
+///
+/// This is used in a variety of function arguments to simplify the processing of `String` and `[String]` values.
+@_documentation(visibility: internal)
+public protocol WhitespaceSeparated {
+    var whitespaceSeparated: [String] { get }
+}
+
+@_documentation(visibility: internal)
+extension String: WhitespaceSeparated {
+    @inlinable public var whitespaceSeparated: [String] {
+        components(separatedBy: .whitespaces)
+    }
+}
+
+@_documentation(visibility: internal)
+extension Array: WhitespaceSeparated where Element == String {
+    @inlinable public var whitespaceSeparated: [String] {
+        self
+    }
+}
+
 /// Indicates a special type of claim whose value is interchangable between a whitespace-separated value, or an array of values.
 ///
 /// This is used to simplify interactions with Claim values whose raw representation is the claim's string value, separated by whitespace. This enables the conversion between the string representation, as sent to/received from the server, and the array of claims which it represents.

--- a/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
+++ b/Sources/AuthFoundation/JWT/Protocols/ClaimCollection.swift
@@ -144,6 +144,7 @@ extension ClaimCollection: RawRepresentable {
     ///
     /// It is recommended that this property be used when representing this list of claims when sending the value to a server.
     public var rawValue: RawValue {
+        // swiftlint:disable force_cast
         if wrappedValue.isNil {
             return (nil as String?) as! RawValue
         }
@@ -152,6 +153,7 @@ extension ClaimCollection: RawRepresentable {
             .array
             .compactMap { $0.stringValue }
             .joined(separator: " ") as! RawValue
+        // swiftlint:enable force_cast
     }
     
     /// Initializer accepting a whitespace-separated string representation of the value.
@@ -180,6 +182,7 @@ extension ClaimCollection where Container.RawValue == String {
 extension ClaimCollection {
     public init(rawValue: Container.RawValue) {
         if Container.self is ExpressibleByNilLiteral {
+            // swiftlint:disable:next force_unwrapping
             self.wrappedValue = Optional<Container>.none!
         } else {
             self.wrappedValue = Container(container: [])

--- a/Sources/AuthFoundation/Network/APIRequestArgument.swift
+++ b/Sources/AuthFoundation/Network/APIRequestArgument.swift
@@ -135,9 +135,9 @@ extension JWT: APIRequestArgument {}
 extension GrantType: APIRequestArgument {}
 
 @_documentation(visibility: private)
-extension [GrantType]: APIRequestArgument {
+extension Array: APIRequestArgument where Element: APIRequestArgument {
     public var stringValue: String {
-        map(\.rawValue)
+        map(\.stringValue)
             .joined(separator: " ")
     }
 }

--- a/Sources/AuthFoundation/OAuth2/Configuration+Initializers.swift
+++ b/Sources/AuthFoundation/OAuth2/Configuration+Initializers.swift
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2024-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Convenience initializers that accept alternate argument types for developer convenience.
+@_documentation(visibility: private)
+extension OAuth2Client.Configuration {
+    @_documentation(visibility: private)
+    @inlinable
+    public init(issuerURL: URL,
+                discoveryURL: URL? = nil,
+                clientId: String,
+                scope: [String],
+                redirectUri: URL? = nil,
+                logoutRedirectUri: URL? = nil,
+                authentication: OAuth2Client.ClientAuthentication = .none)
+    {
+        self.init(issuerURL: issuerURL,
+                  discoveryURL: discoveryURL,
+                  clientId: clientId,
+                  scope: .init(wrappedValue: scope),
+                  redirectUri: redirectUri,
+                  logoutRedirectUri: logoutRedirectUri,
+                  authentication: authentication)
+    }
+    
+    @_documentation(visibility: private)
+    @inlinable
+    public init(issuerURL: URL,
+                discoveryURL: URL? = nil,
+                clientId: String,
+                scope: String,
+                redirectUri: URL? = nil,
+                logoutRedirectUri: URL? = nil,
+                authentication: OAuth2Client.ClientAuthentication = .none)
+    {
+        self.init(issuerURL: issuerURL,
+                  discoveryURL: discoveryURL,
+                  clientId: clientId,
+                  scope: .init(rawValue: scope),
+                  redirectUri: redirectUri,
+                  logoutRedirectUri: logoutRedirectUri,
+                  authentication: authentication)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public init(domain: String,
+                discoveryURL: URL? = nil,
+                clientId: String,
+                scope: [String],
+                redirectUri: String? = nil,
+                logoutRedirectUri: String? = nil,
+                authentication: OAuth2Client.ClientAuthentication = .none) throws
+    {
+        self.init(issuerURL: try URL(requiredString: "https://\(domain)"),
+                  discoveryURL: discoveryURL,
+                  clientId: clientId,
+                  scope: .init(wrappedValue: scope),
+                  redirectUri: try URL(string: redirectUri),
+                  logoutRedirectUri: try URL(string: logoutRedirectUri),
+                  authentication: authentication)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public init(domain: String,
+                discoveryURL: URL? = nil,
+                clientId: String,
+                scope: String,
+                redirectUri: String? = nil,
+                logoutRedirectUri: String? = nil,
+                authentication: OAuth2Client.ClientAuthentication = .none) throws
+    {
+        self.init(issuerURL: try URL(requiredString: "https://\(domain)"),
+                  discoveryURL: discoveryURL,
+                  clientId: clientId,
+                  scope: .init(rawValue: scope),
+                  redirectUri: try URL(string: redirectUri),
+                  logoutRedirectUri: try URL(string: logoutRedirectUri),
+                  authentication: authentication)
+    }
+    
+    @_documentation(visibility: private)
+    @inlinable
+    public init(plist config: OAuth2Client.PropertyListConfiguration) throws {
+        self.init(issuerURL: config.issuerURL,
+                  clientId: config.clientId,
+                  scope: .init(wrappedValue: config.scope),
+                  redirectUri: config.redirectUri,
+                  logoutRedirectUri: config.logoutRedirectUri,
+                  authentication: config.authentication)
+    }
+}

--- a/Sources/AuthFoundation/OAuth2/Configuration+Initializers.swift
+++ b/Sources/AuthFoundation/OAuth2/Configuration+Initializers.swift
@@ -20,7 +20,7 @@ extension OAuth2Client.Configuration {
     public init(issuerURL: URL,
                 discoveryURL: URL? = nil,
                 clientId: String,
-                scope: [String],
+                scope: some WhitespaceSeparated,
                 redirectUri: URL? = nil,
                 logoutRedirectUri: URL? = nil,
                 authentication: OAuth2Client.ClientAuthentication = .none)
@@ -28,26 +28,7 @@ extension OAuth2Client.Configuration {
         self.init(issuerURL: issuerURL,
                   discoveryURL: discoveryURL,
                   clientId: clientId,
-                  scope: .init(wrappedValue: scope),
-                  redirectUri: redirectUri,
-                  logoutRedirectUri: logoutRedirectUri,
-                  authentication: authentication)
-    }
-    
-    @_documentation(visibility: private)
-    @inlinable
-    public init(issuerURL: URL,
-                discoveryURL: URL? = nil,
-                clientId: String,
-                scope: String,
-                redirectUri: URL? = nil,
-                logoutRedirectUri: URL? = nil,
-                authentication: OAuth2Client.ClientAuthentication = .none)
-    {
-        self.init(issuerURL: issuerURL,
-                  discoveryURL: discoveryURL,
-                  clientId: clientId,
-                  scope: .init(rawValue: scope),
+                  scope: .init(wrappedValue: scope.whitespaceSeparated),
                   redirectUri: redirectUri,
                   logoutRedirectUri: logoutRedirectUri,
                   authentication: authentication)
@@ -58,7 +39,7 @@ extension OAuth2Client.Configuration {
     public init(domain: String,
                 discoveryURL: URL? = nil,
                 clientId: String,
-                scope: [String],
+                scope: some WhitespaceSeparated,
                 redirectUri: String? = nil,
                 logoutRedirectUri: String? = nil,
                 authentication: OAuth2Client.ClientAuthentication = .none) throws
@@ -66,26 +47,7 @@ extension OAuth2Client.Configuration {
         self.init(issuerURL: try URL(requiredString: "https://\(domain)"),
                   discoveryURL: discoveryURL,
                   clientId: clientId,
-                  scope: .init(wrappedValue: scope),
-                  redirectUri: try URL(string: redirectUri),
-                  logoutRedirectUri: try URL(string: logoutRedirectUri),
-                  authentication: authentication)
-    }
-
-    @_documentation(visibility: private)
-    @inlinable
-    public init(domain: String,
-                discoveryURL: URL? = nil,
-                clientId: String,
-                scope: String,
-                redirectUri: String? = nil,
-                logoutRedirectUri: String? = nil,
-                authentication: OAuth2Client.ClientAuthentication = .none) throws
-    {
-        self.init(issuerURL: try URL(requiredString: "https://\(domain)"),
-                  discoveryURL: discoveryURL,
-                  clientId: clientId,
-                  scope: .init(rawValue: scope),
+                  scope: .init(wrappedValue: scope.whitespaceSeparated),
                   redirectUri: try URL(string: redirectUri),
                   logoutRedirectUri: try URL(string: logoutRedirectUri),
                   authentication: authentication)

--- a/Sources/AuthFoundation/OAuth2/Internal/ProvidesOAuth2Parameters+Extensions.swift
+++ b/Sources/AuthFoundation/OAuth2/Internal/ProvidesOAuth2Parameters+Extensions.swift
@@ -45,7 +45,7 @@ extension Dictionary<String, APIRequestArgument> {
         }
         
         if let value = self[key] as? String {
-            return value.components(separatedBy: .whitespaces)
+            return value.whitespaceSeparated
         }
         
         return nil

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client+Initializers.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client+Initializers.swift
@@ -40,7 +40,7 @@ extension OAuth2Client {
     public convenience init(issuerURL: URL,
                             discoveryURL: URL? = nil,
                             clientId: String,
-                            scope: [String],
+                            scope: some WhitespaceSeparated,
                             redirectUri: URL? = nil,
                             logoutRedirectUri: URL? = nil,
                             authentication: ClientAuthentication = .none,
@@ -49,36 +49,7 @@ extension OAuth2Client {
         self.init(Configuration(issuerURL: issuerURL,
                                 discoveryURL: discoveryURL,
                                 clientId: clientId,
-                                scope: scope,
-                                redirectUri: redirectUri,
-                                logoutRedirectUri: logoutRedirectUri,
-                                authentication: authentication),
-                  session: session)
-    }
-    
-    /// Constructs an OAuth2Client for the given domain.
-    /// - Parameters:
-    ///   - issuerURL: Issuer URL to use for interactions with the OAuth2 authorization server.
-    ///   - clientId: The unique client ID representing this client.
-    ///   - scope: The whitespace-separated list of OAuth2 scopes requested for this client.
-    ///   - redirectUri: Optional `redirect_uri` value for this client.
-    ///   - logoutRedirectUri: Optional `logout_redirect_uri` value for this client.
-    ///   - authentication: The client authentication  model to use (Default: ``OAuth2Client/ClientAuthentication/none``)
-    ///   - session: Optional URLSession to use for network requests.
-    @inlinable
-    public convenience init(issuerURL: URL,
-                            discoveryURL: URL? = nil,
-                            clientId: String,
-                            scope: String,
-                            redirectUri: URL? = nil,
-                            logoutRedirectUri: URL? = nil,
-                            authentication: ClientAuthentication = .none,
-                            session: URLSessionProtocol? = nil)
-    {
-        self.init(Configuration(issuerURL: issuerURL,
-                                discoveryURL: discoveryURL,
-                                clientId: clientId,
-                                scope: .init(rawValue: scope),
+                                scope: scope.whitespaceSeparated,
                                 redirectUri: redirectUri,
                                 logoutRedirectUri: logoutRedirectUri,
                                 authentication: authentication),

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client+Initializers.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client+Initializers.swift
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2024-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+fileprivate typealias Configuration = OAuth2Client.Configuration
+
+/// Initializers consuming ``OAuth2Client/PropertyListConfiguration``
+@_documentation(visibility: internal)
+extension OAuth2Client {
+    @_documentation(visibility: internal)
+    @inlinable
+    public convenience init(_ config: OAuth2Client.PropertyListConfiguration) throws {
+        self.init(try Configuration(plist: config))
+    }
+}
+
+/// Initializers for accepting client configuration using an Issuer URL.
+@_documentation(visibility: internal)
+extension OAuth2Client {
+    /// Constructs an OAuth2Client for the given domain.
+    /// - Parameters:
+    ///   - issuerURL: Issuer URL to use for interactions with the OAuth2 authorization server.
+    ///   - clientId: The unique client ID representing this client.
+    ///   - scope: The array of OAuth2 scopes requested for this client.
+    ///   - redirectUri: Optional `redirect_uri` value for this client.
+    ///   - logoutRedirectUri: Optional `logout_redirect_uri` value for this client.
+    ///   - authentication: The client authentication  model to use (Default: ``OAuth2Client/ClientAuthentication/none``)
+    ///   - session: Optional URLSession to use for network requests.
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            discoveryURL: URL? = nil,
+                            clientId: String,
+                            scope: [String],
+                            redirectUri: URL? = nil,
+                            logoutRedirectUri: URL? = nil,
+                            authentication: ClientAuthentication = .none,
+                            session: URLSessionProtocol? = nil)
+    {
+        self.init(Configuration(issuerURL: issuerURL,
+                                discoveryURL: discoveryURL,
+                                clientId: clientId,
+                                scope: scope,
+                                redirectUri: redirectUri,
+                                logoutRedirectUri: logoutRedirectUri,
+                                authentication: authentication),
+                  session: session)
+    }
+    
+    /// Constructs an OAuth2Client for the given domain.
+    /// - Parameters:
+    ///   - issuerURL: Issuer URL to use for interactions with the OAuth2 authorization server.
+    ///   - clientId: The unique client ID representing this client.
+    ///   - scope: The whitespace-separated list of OAuth2 scopes requested for this client.
+    ///   - redirectUri: Optional `redirect_uri` value for this client.
+    ///   - logoutRedirectUri: Optional `logout_redirect_uri` value for this client.
+    ///   - authentication: The client authentication  model to use (Default: ``OAuth2Client/ClientAuthentication/none``)
+    ///   - session: Optional URLSession to use for network requests.
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            discoveryURL: URL? = nil,
+                            clientId: String,
+                            scope: String,
+                            redirectUri: URL? = nil,
+                            logoutRedirectUri: URL? = nil,
+                            authentication: ClientAuthentication = .none,
+                            session: URLSessionProtocol? = nil)
+    {
+        self.init(Configuration(issuerURL: issuerURL,
+                                discoveryURL: discoveryURL,
+                                clientId: clientId,
+                                scope: .init(rawValue: scope),
+                                redirectUri: redirectUri,
+                                logoutRedirectUri: logoutRedirectUri,
+                                authentication: authentication),
+                  session: session)
+    }
+}

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -54,32 +54,6 @@ public final class OAuth2Client {
 
     /// Constructs an OAuth2Client for the given domain.
     /// - Parameters:
-    ///   - domain: Okta domain to use when composing the issuer URL.
-    ///   - clientId: The unique client ID representing this client.
-    ///   - scope: The list of OAuth2 scopes requested for this client.
-    ///   - redirectUri: Optional `redirect_uri` value for this client.
-    ///   - logoutRedirectUri: Optional `logout_redirect_uri` value for this client.
-    ///   - authentication: The client authentication  model to use (Default: ``OAuth2Client/ClientAuthentication/none``)
-    ///   - session: Optional URLSession to use for network requests.
-    public convenience init(domain: String,
-                            clientId: String,
-                            scope: String,
-                            redirectUri: String? = nil,
-                            logoutRedirectUri: String? = nil,
-                            authentication: ClientAuthentication = .none,
-                            session: URLSessionProtocol? = nil) throws
-    {
-        self.init(try Configuration(domain: domain,
-                                    clientId: clientId,
-                                    scope: scope,
-                                    redirectUri: redirectUri,
-                                    logoutRedirectUri: logoutRedirectUri,
-                                    authentication: authentication),
-                  session: session)
-    }
-    
-    /// Constructs an OAuth2Client for the given domain.
-    /// - Parameters:
     ///   - issuerURL: The issuer URL for operations against this client.
     ///   - clientId: The unique client ID representing this client.
     ///   - scope: The list of OAuth2 scopes requested for this client.
@@ -87,9 +61,10 @@ public final class OAuth2Client {
     ///   - logoutRedirectUri: Optional `logout_redirect_uri` value for this client.
     ///   - authentication: The client authentication  model to use (Default: `.none`)
     ///   - session: Optional URLSession to use for network requests.
+    @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: String,
+                            scope: ClaimCollection<[String]>,
                             redirectUri: URL? = nil,
                             logoutRedirectUri: URL? = nil,
                             authentication: ClientAuthentication = .none,
@@ -102,15 +77,6 @@ public final class OAuth2Client {
                                 logoutRedirectUri: logoutRedirectUri,
                                 authentication: authentication),
                   session: session)
-    }
-    
-    @_documentation(visibility: internal)
-    public convenience init(_ config: OAuth2Client.PropertyListConfiguration) {
-        self.init(issuerURL: config.issuerURL,
-                  clientId: config.clientId,
-                  scope: config.scope,
-                  redirectUri: config.redirectUri,
-                  logoutRedirectUri: config.logoutRedirectUri)
     }
     
     /// Constructs an OAuth2Client for the given base URL.

--- a/Sources/AuthFoundation/OAuth2/OAuth2ClientConfiguration.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2ClientConfiguration.swift
@@ -83,7 +83,7 @@ extension OAuth2Client {
                   !clientId.isEmpty,
                   let issuer = dict.value("issuer", or: "issuer_url"),
                   let issuerUrl = URL(string: issuer),
-                  let scope = dict.value("scope", or: "scopes")?.components(separatedBy: .whitespaces),
+                  let scope = dict.value("scope", or: "scopes")?.whitespaceSeparated,
                   !scope.isEmpty
             else {
                 throw PropertyListConfigurationError.missingConfigurationValues

--- a/Sources/AuthFoundation/Token Management/IDTokenValidator.swift
+++ b/Sources/AuthFoundation/Token Management/IDTokenValidator.swift
@@ -38,6 +38,7 @@ public protocol IDTokenValidatorContext {
     var maxAge: TimeInterval? { get }
 }
 
+@_documentation(visibility: private)
 public let NullIDTokenValidatorContext: any IDTokenValidatorContext = _NullIDTokenValidatorContext()
 struct _NullIDTokenValidatorContext: IDTokenValidatorContext {
     var nonce: String? { nil }

--- a/Sources/AuthFoundation/Token Management/Token.swift
+++ b/Sources/AuthFoundation/Token Management/Token.swift
@@ -46,7 +46,7 @@ public final class Token: Codable, Equatable, Hashable, JSONClaimContainer, Expi
     public let accessToken: String
     
     /// The scopes requested when this token was generated.
-    public var scope: String? { self[.scope] }
+    public var scope: [String]? { self[.scope] }
     
     /// The refresh token, if requested.
     public var refreshToken: String? { self[.refreshToken] }
@@ -190,7 +190,7 @@ public final class Token: Codable, Equatable, Hashable, JSONClaimContainer, Expi
         
         // When the custom MFA attestation ACR value is used, allow for
         // an empty / unspecified access token.
-        else if let acrValues = context.clientSettings?["acr_values"]?.components(separatedBy: .whitespaces),
+        else if let acrValues = context.clientSettings?["acr_values"]?.whitespaceSeparated,
                 acrValues.contains("urn:okta:app:mfa:attestation")
         {
             accessToken = ""

--- a/Sources/AuthFoundation/Utilities/String+Extensions.swift
+++ b/Sources/AuthFoundation/Utilities/String+Extensions.swift
@@ -47,6 +47,18 @@ extension String {
     @inlinable public var snakeCase: String {
         convertedTo(style: .snakeCase)
     }
+
+    @_documentation(visibility: internal)
+    @inlinable public var whitespaceSeparated: [String] {
+        components(separatedBy: .whitespaces)
+    }
+}
+
+extension Array where Element == String {
+    @_documentation(visibility: internal)
+    @inlinable public var whitespaceSeparated: [String] {
+        self
+    }
 }
 
 @usableFromInline

--- a/Sources/AuthFoundation/Utilities/String+Extensions.swift
+++ b/Sources/AuthFoundation/Utilities/String+Extensions.swift
@@ -47,18 +47,6 @@ extension String {
     @inlinable public var snakeCase: String {
         convertedTo(style: .snakeCase)
     }
-
-    @_documentation(visibility: internal)
-    @inlinable public var whitespaceSeparated: [String] {
-        components(separatedBy: .whitespaces)
-    }
-}
-
-extension Array where Element == String {
-    @_documentation(visibility: internal)
-    @inlinable public var whitespaceSeparated: [String] {
-        self
-    }
 }
 
 @usableFromInline

--- a/Sources/AuthFoundation/Utilities/URL+InternalExtensions.swift
+++ b/Sources/AuthFoundation/Utilities/URL+InternalExtensions.swift
@@ -32,4 +32,16 @@ extension URL {
         #endif
         // swiftlint:enable force_unwrapping
     }
+    
+    @inlinable
+    var appendingDiscoveryURL: URL {
+        var relativeURL = self
+        
+        // Ensure the base URL contains a trailing slash in its path, so request paths can be safely appended.
+        if !relativeURL.lastPathComponent.isEmpty {
+            relativeURL = relativeURL.appendingComponent("")
+        }
+        
+        return relativeURL.appendingComponent(".well-known/openid-configuration")
+    }
 }

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -181,6 +181,7 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
     /// Configuration which can be used to customize the authentication flow, as needed.
     public struct Context: AuthenticationContext, Equatable {
         /// The ACR values, if any, which should be requested by the client.
+        @ClaimCollection
         public var acrValues: [String]?
 
         /// The intent of the current flow.
@@ -193,10 +194,10 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
         /// - Parameters:
         ///   - acrValues: Optional `acr_values` to supply.
         ///   - intent: The intent for this sign-in. Defaults to ``DirectAuthenticationFlow/Intent/signIn``.
-        public init(acrValues: [String]? = nil,
+        public init(acrValues: ClaimCollection<[String]?> = nil,
                     intent: Intent = .signIn)
         {
-            self.acrValues = acrValues
+            self._acrValues = acrValues
             self.intent = intent
         }
 
@@ -204,8 +205,8 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
         public func parameters(for category: OAuth2APIRequestCategory) -> [String: any APIRequestArgument]? {
             var result: [String: any APIRequestArgument] = [:]
             
-            if let acrValues = acrValues {
-                result["acr_values"] = acrValues.joined(separator: " ")
+            if let values = $acrValues.rawValue {
+                result["acr_values"] = values
             }
             
             if category == .token {
@@ -337,7 +338,7 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
     ///   - additionalParameters: Custom request parameters to be added to requests made for this sign-in.
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: String,
+                            scope: ClaimCollection<[String]>,
                             supportedGrants grantTypes: [GrantType] = .directAuth,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -342,9 +342,24 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
                             supportedGrants grantTypes: [GrantType] = .directAuth,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(client: .init(issuerURL: issuerURL,
-                                clientId: clientId,
-                                scope: scope),
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
+                  supportedGrants: grantTypes,
+                  additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: some WhitespaceSeparated,
+                            supportedGrants grantTypes: [GrantType] = .directAuth,
+                            additionalParameters: [String: any APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
                   supportedGrants: grantTypes,
                   additionalParameters: additionalParameters)
     }

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -484,10 +484,14 @@ public class DirectAuthenticationFlow: AuthenticationFlow {
     
     /// Resets the authentication session.
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
     }
 
+    func finished() {
+        isAuthenticating = false
+    }
+    
     // MARK: Private properties / methods
     public let delegateCollection = DelegateCollection<DirectAuthenticationFlowDelegate>()
 }

--- a/Sources/OktaDirectAuth/Internal/DirectAuthFlow+SendResponses.swift
+++ b/Sources/OktaDirectAuth/Internal/DirectAuthFlow+SendResponses.swift
@@ -19,7 +19,7 @@ extension DirectAuthenticationFlow {
         delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
         completion(.success(.success(response.result)))
 
-        reset()
+        finished()
     }
 
     func send(state: Status,
@@ -37,6 +37,6 @@ extension DirectAuthenticationFlow {
 
         completion(.failure(DirectAuthenticationFlowError(error)))
 
-        reset()
+        finished()
     }
 }

--- a/Sources/OktaDirectAuth/Internal/Requests/OOBAuthenticateRequest.swift
+++ b/Sources/OktaDirectAuth/Internal/Requests/OOBAuthenticateRequest.swift
@@ -42,6 +42,7 @@ struct OOBResponse: Codable, Equatable, HasTokenParameters {
         && abs((lhs.interval ?? 0) - (rhs.interval ?? 0)) < tolerance
         && lhs.channel == rhs.channel
         && lhs.bindingMethod == rhs.bindingMethod
+        && lhs.bindingCode == rhs.bindingCode
     }
 }
 

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -116,10 +116,10 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
                             redirectUri: URL,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(verifiedClient: .init(issuerURL: issuerURL,
-                                        clientId: clientId,
-                                        scope: scope,
-                                        redirectUri: redirectUri),
+        self.init(verifiedClient: OAuth2Client(issuerURL: issuerURL,
+                                               clientId: clientId,
+                                               scope: scope,
+                                               redirectUri: redirectUri),
                   additionalParameters: additionalParameters)
     }
     
@@ -127,29 +127,14 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
     @_documentation(visibility: private)
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
+                            scope: some WhitespaceSeparated,
                             redirectUri: URL,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(verifiedClient: .init(issuerURL: issuerURL,
-                                        clientId: clientId,
-                                        scope: .init(wrappedValue: scope),
-                                        redirectUri: redirectUri),
-                  additionalParameters: additionalParameters)
-    }
-
-    @inlinable
-    @_documentation(visibility: private)
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
-                            redirectUri: URL,
-                            additionalParameters: [String: any APIRequestArgument]? = nil)
-    {
-        self.init(verifiedClient: .init(issuerURL: issuerURL,
-                                        clientId: clientId,
-                                        scope: .init(wrappedValue: scope),
-                                        redirectUri: redirectUri),
+        self.init(verifiedClient: OAuth2Client(issuerURL: issuerURL,
+                                               clientId: clientId,
+                                               scope: .init(wrappedValue: scope.whitespaceSeparated),
+                                               redirectUri: redirectUri),
                   additionalParameters: additionalParameters)
     }
 

--- a/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/AuthorizationCodeFlow.swift
@@ -197,7 +197,7 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
-                self.reset()
+                self.finished()
                 
             case .success(let configuration):
                 do {
@@ -216,7 +216,7 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
                     let oauthError = error as? OAuth2Error ?? .error(error)
                     self.delegateCollection.invoke { $0.authentication(flow: self, received: oauthError) }
                     completion(.failure(oauthError))
-                    self.reset()
+                    self.finished()
                 }
             }
         }
@@ -258,12 +258,12 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
                     self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                     completion(.failure(error))
 
-                    self.reset()
+                    self.finished()
                     return
                 }
                 
                 self.client.exchange(token: request) { result in
-                    defer { self.reset() }
+                    defer { self.finished() }
                     
                     switch result {
                     case .success(let response):
@@ -278,14 +278,18 @@ public class AuthorizationCodeFlow: AuthenticationFlow {
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
-                self.reset()
+                self.finished()
             }
         }
     }
     
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        isAuthenticating = false
     }
 
     // MARK: Private properties / methods

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -94,14 +94,41 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
     ///   - clientId: The client ID
     ///   - scope: The scopes to request
     ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: ClaimCollection<[String]>,
+                            additionalParameters: [String: any APIRequestArgument]? = nil)
+    {
+        self.init(client: .init(issuerURL: issuerURL,
+                                clientId: clientId,
+                                scope: scope),
+                  additionalParameters: additionalParameters)
+    }
+    
+    @inlinable
+    @_documentation(visibility: private)
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: [String],
+                            additionalParameters: [String: any APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(OAuth2Client.Configuration(issuerURL: issuerURL,
+                                                                  clientId: clientId,
+                                                                  scope: scope)),
+                  additionalParameters: additionalParameters)
+    }
+    
+    @inlinable
+    @_documentation(visibility: private)
     public convenience init(issuerURL: URL,
                             clientId: String,
                             scope: String,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(client: OAuth2Client(issuerURL: issuerURL,
-                                       clientId: clientId,
-                                       scope: scope),
+        self.init(client: OAuth2Client(OAuth2Client.Configuration(issuerURL: issuerURL,
+                                                                  clientId: clientId,
+                                                                  scope: scope)),
                   additionalParameters: additionalParameters)
     }
 
@@ -214,13 +241,13 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
             self.getToken(deviceCode: verification.deviceCode, context: context) { result in
                 switch result {
                 case .failure(let error):
-                    self.reset()
                     completion?(.failure(.network(error: error)))
-                    
+                    self.reset()
+
                 case .success(let token):
                     if let token = token {
-                        self.reset()
                         completion?(.success(token))
+                        self.reset()
                     }
                 }
             }

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -206,11 +206,15 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
     
     /// Resets the flow for later reuse.
     public func reset() {
+        finished()
+        context = nil
+    }
+    
+    func finished() {
         timer?.cancel()
         timer = nil
         completion = nil
         isAuthenticating = false
-        context = nil
     }
 
     // MARK: Private properties / methods
@@ -242,12 +246,12 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
                 switch result {
                 case .failure(let error):
                     completion?(.failure(.network(error: error)))
-                    self.reset()
+                    self.finished()
 
                 case .success(let token):
                     if let token = token {
                         completion?(.success(token))
-                        self.reset()
+                        self.finished()
                     }
                 }
             }

--- a/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/DeviceAuthorizationFlow.swift
@@ -100,9 +100,9 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
                             scope: ClaimCollection<[String]>,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(client: .init(issuerURL: issuerURL,
-                                clientId: clientId,
-                                scope: scope),
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
                   additionalParameters: additionalParameters)
     }
     
@@ -110,28 +110,15 @@ public class DeviceAuthorizationFlow: AuthenticationFlow {
     @_documentation(visibility: private)
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
+                            scope: some WhitespaceSeparated,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(client: OAuth2Client(OAuth2Client.Configuration(issuerURL: issuerURL,
-                                                                  clientId: clientId,
-                                                                  scope: scope)),
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
                   additionalParameters: additionalParameters)
     }
     
-    @inlinable
-    @_documentation(visibility: private)
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
-                            additionalParameters: [String: any APIRequestArgument]? = nil)
-    {
-        self.init(client: OAuth2Client(OAuth2Client.Configuration(issuerURL: issuerURL,
-                                                                  clientId: clientId,
-                                                                  scope: scope)),
-                  additionalParameters: additionalParameters)
-    }
-
     /// Initializer to construct an authentication flow from a pre-defined configuration and client.
     /// - Parameters:
     ///   - client: The `OAuth2Client` to use with this flow.

--- a/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
@@ -135,21 +135,25 @@ public class JWTAuthorizationFlow: AuthenticationFlow {
                         completion(.success(response.result))
                     }
                     
-                    self.reset()
+                    self.finished()
                 }
 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
-                self.reset()
+                self.finished()
             }
         }
     }
     
     /// Resets the flow for later reuse.
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        isAuthenticating = false
     }
 
     // MARK: Private properties / methods

--- a/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
@@ -148,8 +148,8 @@ public class JWTAuthorizationFlow: AuthenticationFlow {
     
     /// Resets the flow for later reuse.
     public func reset() {
-        context = nil
         isAuthenticating = false
+        context = nil
     }
 
     // MARK: Private properties / methods

--- a/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/JWTAuthorizationFlow.swift
@@ -54,9 +54,9 @@ public class JWTAuthorizationFlow: AuthenticationFlow {
                             scope: ClaimCollection<[String]>,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(client: OAuth2Client(issuerURL: issuerURL,
-                                       clientId: clientId,
-                                       scope: scope),
+        self.init(client: .init(issuerURL: issuerURL,
+                                clientId: clientId,
+                                scope: scope),
                   additionalParameters: additionalParameters)
     }
 
@@ -64,25 +64,12 @@ public class JWTAuthorizationFlow: AuthenticationFlow {
     @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
+                            scope: some WhitespaceSeparated,
                             additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        self.init(issuerURL: issuerURL,
-                  clientId: clientId,
-                  scope: .init(wrappedValue: scope),
-                  additionalParameters: additionalParameters)
-    }
-    
-    @_documentation(visibility: private)
-    @inlinable
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
-                            additionalParameters: [String: any APIRequestArgument]? = nil)
-    {
-        self.init(issuerURL: issuerURL,
-                  clientId: clientId,
-                  scope: .init(rawValue: scope),
+        self.init(client: .init(issuerURL: issuerURL,
+                                clientId: clientId,
+                                scope: scope),
                   additionalParameters: additionalParameters)
     }
     

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -141,21 +141,25 @@ public class ResourceOwnerFlow: AuthenticationFlow {
                         completion(.success(response.result))
                     }
 
-                    self.reset()
+                    self.finished()
                 }
 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
-                self.reset()
+                self.finished()
             }
         }
     }
     
     /// Resets the flow for later reuse.
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        isAuthenticating = false
     }
 
     // MARK: Private properties / methods

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -67,7 +67,7 @@ public class ResourceOwnerFlow: AuthenticationFlow {
     @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
+                            scope: some WhitespaceSeparated,
                             additionalParameters: [String: APIRequestArgument]? = nil)
     {
         self.init(client: OAuth2Client(issuerURL: issuerURL,
@@ -76,19 +76,6 @@ public class ResourceOwnerFlow: AuthenticationFlow {
                   additionalParameters: additionalParameters)
     }
 
-    @_documentation(visibility: private)
-    @inlinable
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
-                            additionalParameters: [String: APIRequestArgument]? = nil)
-    {
-        self.init(client: OAuth2Client(issuerURL: issuerURL,
-                                       clientId: clientId,
-                                       scope: scope),
-                  additionalParameters: additionalParameters)
-    }
-    
     /// Initializer that uses the predefined OAuth2Client
     /// - Parameters:
     ///   - client: ``OAuth2Client`` client instance to authenticate with.

--- a/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/ResourceOwnerFlow.swift
@@ -51,6 +51,33 @@ public class ResourceOwnerFlow: AuthenticationFlow {
     ///   - clientId: The client ID
     ///   - scope: The scopes to request
     ///   - additionalParameters: Optional parameters to supply tot he authorization server for all requests from this flow.
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: ClaimCollection<[String]>,
+                            additionalParameters: [String: APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
+                  additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: [String],
+                            additionalParameters: [String: APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
+                  additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
                             scope: String,
@@ -105,8 +132,6 @@ public class ResourceOwnerFlow: AuthenticationFlow {
                                            username: username,
                                            password: password)
                 self.client.exchange(token: request) { result in
-                    self.reset()
-                    
                     switch result {
                     case .failure(let error):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: .network(error: error)) }
@@ -115,11 +140,14 @@ public class ResourceOwnerFlow: AuthenticationFlow {
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response.result) }
                         completion(.success(response.result))
                     }
+
+                    self.reset()
                 }
 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
+                self.reset()
             }
         }
     }

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -156,7 +156,7 @@ public class SessionTokenFlow: AuthenticationFlow {
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response) }
                         completion(.success(response))
                     }
-                    self.reset()
+                    self.finished()
                 }
             }
         }
@@ -164,8 +164,12 @@ public class SessionTokenFlow: AuthenticationFlow {
     
     /// Resets the flow for later reuse.
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        isAuthenticating = false
     }
 
     // MARK: Private properties / methods

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -53,6 +53,37 @@ public class SessionTokenFlow: AuthenticationFlow {
     ///   - clientId: The client ID
     ///   - scope: The scopes to request
     ///   - additionalParameters: Optional query parameters to supply tot he authorization server for all requests from this flow.
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: ClaimCollection<[String]>,
+                            redirectUri: URL,
+                            additionalParameters: [String: APIRequestArgument]? = nil) throws
+    {
+        try self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                           clientId: clientId,
+                                           scope: scope,
+                                           redirectUri: redirectUri),
+                      additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: [String],
+                            redirectUri: URL,
+                            additionalParameters: [String: APIRequestArgument]? = nil) throws
+    {
+        try self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                           clientId: clientId,
+                                           scope: scope,
+                                           redirectUri: redirectUri),
+                      additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
                             scope: String,
@@ -117,8 +148,6 @@ public class SessionTokenFlow: AuthenticationFlow {
                 completion(.failure(error))
             case .success(let response):
                 self.complete(using: flow, url: response) { result in
-                    self.reset()
-                    
                     switch result {
                     case .failure(let error):
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
@@ -127,6 +156,7 @@ public class SessionTokenFlow: AuthenticationFlow {
                         self.delegateCollection.invoke { $0.authentication(flow: self, received: response) }
                         completion(.success(response))
                     }
+                    self.reset()
                 }
             }
         }

--- a/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/SessionTokenFlow.swift
@@ -71,22 +71,7 @@ public class SessionTokenFlow: AuthenticationFlow {
     @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
-                            redirectUri: URL,
-                            additionalParameters: [String: APIRequestArgument]? = nil) throws
-    {
-        try self.init(client: OAuth2Client(issuerURL: issuerURL,
-                                           clientId: clientId,
-                                           scope: scope,
-                                           redirectUri: redirectUri),
-                      additionalParameters: additionalParameters)
-    }
-
-    @_documentation(visibility: private)
-    @inlinable
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
+                            scope: some WhitespaceSeparated,
                             redirectUri: URL,
                             additionalParameters: [String: APIRequestArgument]? = nil) throws
     {

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -87,20 +87,7 @@ public class TokenExchangeFlow: AuthenticationFlow {
     @inlinable
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: [String],
-                            additionalParameters: [String: APIRequestArgument]? = nil)
-    {
-        self.init(client: OAuth2Client(issuerURL: issuerURL,
-                                       clientId: clientId,
-                                       scope: scope),
-                  additionalParameters: additionalParameters)
-    }
-
-    @_documentation(visibility: private)
-    @inlinable
-    public convenience init(issuerURL: URL,
-                            clientId: String,
-                            scope: String,
+                            scope: some WhitespaceSeparated,
                             additionalParameters: [String: APIRequestArgument]? = nil)
     {
         self.init(client: OAuth2Client(issuerURL: issuerURL,

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -166,20 +166,24 @@ public class TokenExchangeFlow: AuthenticationFlow {
                         completion(.success(response.result))
                     }
                     
-                    self.reset()
+                    self.finished()
                 }
                 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
-                self.reset()
+                self.finished()
             }
         }
     }
 
     public func reset() {
-        isAuthenticating = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        isAuthenticating = false
     }
 }
 

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -74,6 +74,32 @@ public class TokenExchangeFlow: AuthenticationFlow {
     ///   - additionalParameters: Optional query parameters to supply tot he authorization server for all requests from this flow.
     public convenience init(issuerURL: URL,
                             clientId: String,
+                            scope: ClaimCollection<[String]>,
+                            additionalParameters: [String: APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
+                  additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: [String],
+                            additionalParameters: [String: APIRequestArgument]? = nil)
+    {
+        self.init(client: OAuth2Client(issuerURL: issuerURL,
+                                       clientId: clientId,
+                                       scope: scope),
+                  additionalParameters: additionalParameters)
+    }
+
+    @_documentation(visibility: private)
+    @inlinable
+    public convenience init(issuerURL: URL,
+                            clientId: String,
                             scope: String,
                             additionalParameters: [String: APIRequestArgument]? = nil)
     {

--- a/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OktaOAuth2/Authentication/TokenExchangeFlow.swift
@@ -166,12 +166,13 @@ public class TokenExchangeFlow: AuthenticationFlow {
                         completion(.success(response.result))
                     }
                     
-                    self.isAuthenticating = false
+                    self.reset()
                 }
                 
             case .failure(let error):
                 self.delegateCollection.invoke { $0.authentication(flow: self, received: error) }
                 completion(.failure(error))
+                self.reset()
             }
         }
     }

--- a/Sources/OktaOAuth2/Deprecations/AuthorizationCodeFlow+Deprecations.swift
+++ b/Sources/OktaOAuth2/Deprecations/AuthorizationCodeFlow+Deprecations.swift
@@ -27,8 +27,8 @@ extension AuthorizationCodeFlow {
     @_documentation(visibility: private)
     @available(*, deprecated, renamed: "init(client:additionalParameters:)")
     public convenience init(redirectUri: URL,
-                additionalParameters: [String: APIRequestArgument]?,
-                client: OAuth2Client)
+                            additionalParameters: [String: APIRequestArgument]?,
+                            client: OAuth2Client)
     {
         fatalError()
     }
@@ -41,7 +41,10 @@ extension AuthorizationCodeFlow {
     {
         fatalError()
     }
+}
 
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6, *)
+extension AuthorizationCodeFlow {
     @_documentation(visibility: private)
     @available(*, deprecated, renamed: "start(with:)")
     public func start(with context: Context?, additionalParameters: [String: String]?) async throws -> URL

--- a/Sources/OktaOAuth2/Deprecations/JWTAuthorizationFlow+Deprecations.swift
+++ b/Sources/OktaOAuth2/Deprecations/JWTAuthorizationFlow+Deprecations.swift
@@ -19,6 +19,6 @@ extension JWTAuthorizationFlow {
                             clientId: String,
                             scopes: String)
     {
-        self.init(issuerURL: issuer, clientId: clientId, scope: scopes)
+        self.init(issuerURL: issuer, clientId: clientId, scope: .init(rawValue: scopes))
     }
 }

--- a/Sources/OktaOAuth2/Deprecations/ResourceOwnerFlow+Deprecations.swift
+++ b/Sources/OktaOAuth2/Deprecations/ResourceOwnerFlow+Deprecations.swift
@@ -19,6 +19,6 @@ extension ResourceOwnerFlow {
                             clientId: String,
                             scopes: String)
     {
-        self.init(issuerURL: issuer, clientId: clientId, scope: scopes)
+        self.init(issuerURL: issuer, clientId: clientId, scope: .init(rawValue: scopes))
     }
 }

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow+Context.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow+Context.swift
@@ -76,6 +76,7 @@ extension SessionLogoutFlow {
             && lhs.idToken == rhs.idToken
             && lhs.logoutHint == rhs.logoutHint
             && lhs.additionalParameters?.mapValues(\.stringValue) == rhs.additionalParameters?.mapValues(\.stringValue)
+            && lhs.logoutURL == rhs.logoutURL
         }
     }
 }

--- a/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
+++ b/Sources/OktaOAuth2/Logout/SessionLogoutFlow.swift
@@ -126,7 +126,7 @@ public class SessionLogoutFlow: LogoutFlow {
         inProgress = true
         
         client.openIdConfiguration { result in
-            defer { self.reset() }
+            defer { self.finished() }
 
             switch result {
             case .failure(let error):
@@ -162,8 +162,12 @@ public class SessionLogoutFlow: LogoutFlow {
     
     /// Resets a current session logout flow.
     public func reset() {
-        inProgress = false
+        finished()
         context = nil
+    }
+    
+    func finished() {
+        inProgress = false
     }
 
     public let delegateCollection = DelegateCollection<SessionLogoutFlowDelegate>()

--- a/Sources/WebAuthenticationUI/WebAuthentication.swift
+++ b/Sources/WebAuthenticationUI/WebAuthentication.swift
@@ -253,7 +253,23 @@ public class WebAuthentication {
     ///   - additionalParameters: Optional parameters to add to the authorization query string.
     public convenience init(issuerURL: URL,
                             clientId: String,
-                            scope: String,
+                            scope: ClaimCollection<[String]>,
+                            redirectUri: URL,
+                            logoutRedirectUri: URL? = nil,
+                            additionalParameters: [String: APIRequestArgument]? = nil) throws
+    {
+        let client = OAuth2Client(issuerURL: issuerURL,
+                                  clientId: clientId,
+                                  scope: scope,
+                                  redirectUri: redirectUri,
+                                  logoutRedirectUri: logoutRedirectUri)
+        try self.init(client: client, additionalParameters: additionalParameters)
+    }
+    
+    @_documentation(visibility: private)
+    public convenience init(issuerURL: URL,
+                            clientId: String,
+                            scope: some WhitespaceSeparated,
                             redirectUri: URL,
                             logoutRedirectUri: URL? = nil,
                             additionalParameters: [String: APIRequestArgument]? = nil) throws

--- a/Tests/AuthFoundationTests/AuthenticationContextTests.swift
+++ b/Tests/AuthFoundationTests/AuthenticationContextTests.swift
@@ -59,11 +59,11 @@ final class AuthenticationContextTests: XCTestCase {
             }
         }
         
-        context = .init(acrValues: nil, additionalParameters: ["acr_values": "foo"])
+        context = .init(additionalParameters: ["acr_values": "foo"])
         XCTAssertEqual(context.acrValues, ["foo"])
         XCTAssertNil(context.additionalParameters)
 
-        context = .init(acrValues: nil, additionalParameters: nil)
+        context = .init()
         XCTAssertNil(context.acrValues)
         XCTAssertNil(context.additionalParameters)
     }

--- a/Tests/AuthFoundationTests/AuthenticationFlowTests.swift
+++ b/Tests/AuthFoundationTests/AuthenticationFlowTests.swift
@@ -91,7 +91,7 @@ final class AuthenticationFlowTests: XCTestCase {
     
     func testValidatorContextHandling() throws {
         let flow = try TestFlow(client: client, additionalParameters: nil)
-        flow.context = .init(nonce: "abcd123", maxAge: 60)
+        flow.context = .init(acrValues: [], nonce: "abcd123", maxAge: 60)
         
         XCTAssertEqual(flow.nonce, "abcd123")
         XCTAssertEqual(flow.maxAge, 60.0)

--- a/Tests/AuthFoundationTests/ClaimListTests.swift
+++ b/Tests/AuthFoundationTests/ClaimListTests.swift
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2025-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import AuthFoundation
+import TestCommon
+
+struct TestStringArrayClaimProperty {
+    @ClaimCollection
+    var values: [String]
+}
+
+struct TestEnumArrayClaimProperty {
+    enum Role: String, Equatable, ClaimConvertable, APIRequestArgument {
+        case admin, superuser, user, guest
+    }
+    
+    @ClaimCollection
+    var values: [Role]
+}
+
+struct TestOptionalStringArrayClaimProperty {
+    @ClaimCollection
+    var values: [String]?
+}
+
+final class ClaimCollectionTests: XCTestCase {
+    func testStringClaimCollectionPropertyWrapper() throws {
+        var value = TestStringArrayClaimProperty(values: [])
+        XCTAssertEqual(value.values, [])
+        XCTAssertEqual(value.$values.rawValue, "")
+        
+        value.values = ["a", "b", "c"]
+        XCTAssertEqual(value.values, ["a", "b", "c"])
+        XCTAssertEqual(value.$values.wrappedValue, ["a", "b", "c"])
+        XCTAssertEqual(value.$values.rawValue, "a b c")
+        
+        value.values.remove(at: 1)
+        XCTAssertEqual(value.values, ["a", "c"])
+        XCTAssertEqual(value.$values.wrappedValue, ["a", "c"])
+        XCTAssertEqual(value.$values.rawValue, "a c")
+        
+        value.values.append("a")
+        XCTAssertEqual(value.values, ["a", "c", "a"])
+        XCTAssertEqual(value.$values.wrappedValue, ["a", "c", "a"])
+        XCTAssertEqual(value.$values.rawValue, "a c a")
+        
+        var optional = TestOptionalStringArrayClaimProperty(values: nil)
+        XCTAssertNil(optional.values)
+        XCTAssertNil(optional.$values.rawValue)
+
+        optional.values = ["a"]
+        XCTAssertEqual(optional.values, ["a"])
+        XCTAssertEqual(optional.$values.wrappedValue, ["a"])
+        XCTAssertEqual(optional.$values.rawValue, "a")
+        
+        optional.values?.append(contentsOf: ["b", "c"])
+        XCTAssertEqual(optional.values, ["a", "b", "c"])
+        XCTAssertEqual(optional.$values.wrappedValue, ["a", "b", "c"])
+        XCTAssertEqual(optional.$values.rawValue, "a b c")
+    }
+
+    func testEnumClaimCollectionPropertyWrapper() throws {
+        var value = TestEnumArrayClaimProperty(values: [])
+        XCTAssertEqual(value.values, [])
+        XCTAssertEqual(value.$values.rawValue, "")
+        
+        value.values = [.admin, .guest]
+        XCTAssertEqual(value.values, [.admin, .guest])
+        XCTAssertEqual(value.$values.wrappedValue, [.admin, .guest])
+        XCTAssertEqual(value.$values.rawValue, "admin guest")
+        
+        value.values.remove(at: 1)
+        XCTAssertEqual(value.values, [.admin])
+        XCTAssertEqual(value.$values.wrappedValue, [.admin])
+        XCTAssertEqual(value.$values.rawValue, "admin")
+        
+        value.values.append(.admin)
+        XCTAssertEqual(value.values, [.admin, .admin])
+        XCTAssertEqual(value.$values.wrappedValue, [.admin, .admin])
+        XCTAssertEqual(value.$values.rawValue, "admin admin")
+        
+        value = TestEnumArrayClaimProperty(values: [.admin, .superuser])
+        XCTAssertEqual(value.values, [.admin, .superuser])
+        XCTAssertEqual(value.$values.rawValue, "admin superuser")
+    }
+    
+    func testStringClaimCollectionVariable() throws {
+        var list = ClaimCollection<[String]>()
+        XCTAssertEqual(list.rawValue, "")
+        
+        list.wrappedValue = ["a", "b", "c"]
+        XCTAssertEqual(list.rawValue, "a b c")
+        
+        list.wrappedValue.removeAll()
+        XCTAssertEqual(list.rawValue, "")
+        
+        list = ClaimCollection<[String]>(wrappedValue: ["x", "y", "z"])
+        XCTAssertEqual(list.rawValue, "x y z")
+
+        list = try XCTUnwrap(ClaimCollection<[String]>(rawValue: "red green blue"))
+        XCTAssertEqual(list.rawValue, "red green blue")
+
+        list = ["1", "2", "3"]
+        XCTAssertEqual(list.rawValue, "1 2 3")
+        
+        list = "one two three"
+        XCTAssertEqual(list.rawValue, "one two three")
+    }
+
+    func testEnumClaimCollectionVariable() throws {
+        var list = ClaimCollection<[TestEnumArrayClaimProperty.Role]>()
+        XCTAssertEqual(list.rawValue, "")
+        
+        list.wrappedValue = [.admin, .guest, .user]
+        XCTAssertEqual(list.rawValue, "admin guest user")
+        
+        list.wrappedValue.removeAll()
+        XCTAssertEqual(list.rawValue, "")
+        
+        list = ClaimCollection<[TestEnumArrayClaimProperty.Role]>(wrappedValue: [.superuser, .admin])
+        XCTAssertEqual(list.rawValue, "superuser admin")
+
+        list = try XCTUnwrap(ClaimCollection<[TestEnumArrayClaimProperty.Role]>(rawValue: "user guest"))
+        XCTAssertEqual(list, [.user, .guest])
+        XCTAssertEqual(list.rawValue, "user guest")
+
+        list = [.admin, .user]
+        XCTAssertEqual(list.rawValue, "admin user")
+        
+        list = "guest user"
+        XCTAssertEqual(list, [.guest, .user])
+        XCTAssertEqual(list.rawValue, "guest user")
+    }
+}

--- a/Tests/AuthFoundationTests/ClaimTests.swift
+++ b/Tests/AuthFoundationTests/ClaimTests.swift
@@ -46,6 +46,7 @@ final class ClaimTests: XCTestCase {
             "modifiedDate": dateString,
             "webpage": "https://example.com/jane.doe/",
             "roles": ["admin", "user"],
+            "scope": "openid profile offline_access",
             "tags": [
                 "popular": "Popular Items",
                 "normal": "Normal Items",
@@ -62,6 +63,11 @@ final class ClaimTests: XCTestCase {
         XCTAssertEqual(container["modifiedDate"], dateString)
         XCTAssertEqual(container[.modifiedDate], dateString)
         XCTAssertEqual(date, try container.value(for: "modifiedDate"))
+
+        XCTAssertEqual(container["scope"], "openid profile offline_access")
+        XCTAssertEqual(container["scope"] as [String]?, ["openid", "profile", "offline_access"])
+        XCTAssertEqual(container.value(for: "scope") as [String]?, ["openid", "profile", "offline_access"])
+        XCTAssertEqual(try container.value(for: "scope") as [String], ["openid", "profile", "offline_access"])
 
         XCTAssertEqual(container["roles"], ["admin", "user"])
         XCTAssertEqual(container[.roles], ["admin", "user"])

--- a/Tests/AuthFoundationTests/JWTTests.swift
+++ b/Tests/AuthFoundationTests/JWTTests.swift
@@ -25,7 +25,7 @@ final class JWTTests: XCTestCase {
         XCTAssertEqual(token[.userId], "00u2q5p3AAAOXoSc04w5")
         XCTAssertEqual(token[.clientId], "0oa3en4fAAA3ddc204w5")
         XCTAssertEqual(token.issuer, "https://example.com/oauth2/default")
-        XCTAssertNil(token.audience)
+        XCTAssertEqual(token.audience, "api://default")
         XCTAssertEqual(token.expirationTime?.timeIntervalSinceReferenceDate, 664228962.0)
         XCTAssertEqual(token.issuedAt?.timeIntervalSinceReferenceDate, 664225362.0)
         XCTAssertNil(token.notBefore)

--- a/Tests/AuthFoundationTests/OAuth2ClientConfigurationTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientConfigurationTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2025-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import TestCommon
+@testable import AuthFoundation
+
+#if os(Linux)
+import FoundationNetworking
+#endif
+
+final class OAuth2ClientConfigurationTests: XCTestCase {
+    func testInitializers() throws {
+        var configuration: OAuth2Client.Configuration!
+        
+        // Tewst with a string literal scope
+        configuration = .init(issuerURL: URL(string: "https://example.com")!,
+                              clientId: "abcd123",
+                              scope: "openid profile",
+                              authentication: .none)
+        XCTAssertEqual(configuration.discoveryURL.absoluteString, "https://example.com/.well-known/openid-configuration")
+        XCTAssertEqual(configuration.scope, ["openid", "profile"])
+        XCTAssertEqual(configuration.parameters(for: .authorization)?.mapValues(\.stringValue), [
+            "client_id": "abcd123",
+            "scope": "openid profile",
+        ])
+        
+        // Test with an array literal scope
+        configuration = .init(issuerURL: URL(string: "https://example.com/oauth2/default")!,
+                              clientId: "abcd123",
+                              scope: ["openid", "email"],
+                              redirectUri: URL(string: "com.example.app:/"),
+                              logoutRedirectUri: URL(string: "com.example.app:/logout"),
+                              authentication: .clientSecret("super_secret"))
+        XCTAssertEqual(configuration.discoveryURL.absoluteString, "https://example.com/oauth2/default/.well-known/openid-configuration")
+        XCTAssertEqual(configuration.scope, ["openid", "email"])
+        XCTAssertEqual(configuration.parameters(for: .authorization)?.mapValues(\.stringValue), [
+            "client_id": "abcd123",
+            "client_secret": "super_secret",
+            "redirect_uri": "com.example.app:/",
+            "scope": "openid email",
+        ])
+
+        // Test with a string value scope
+        var scopeString = "openid profile"
+        configuration = .init(issuerURL: URL(string: "https://example.com")!,
+                              clientId: "abcd123",
+                              scope: scopeString,
+                              authentication: .none)
+        XCTAssertEqual(configuration.scope, ["openid", "profile"])
+
+        // Test with an array value scope
+        var scopeArray = ["openid", "email"]
+        configuration = .init(issuerURL: URL(string: "https://example.com")!,
+                              clientId: "abcd123",
+                              scope: scopeArray,
+                              authentication: .none)
+        XCTAssertEqual(configuration.scope, ["openid", "email"])
+    }
+    
+    func testConfiguration() throws {
+        XCTAssertNotEqual(try OAuth2Client.Configuration(domain: "example.com",
+                                                         clientId: "abc123",
+                                                         scope: "openid profile",
+                                                         authentication: .none),
+                          try OAuth2Client.Configuration(domain: "example.com",
+                                                         clientId: "abc123",
+                                                         scope: "openid profile",
+                                                         authentication: .clientSecret("supersecret")))
+    }
+}

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -50,9 +50,9 @@ final class OAuth2ClientTests: XCTestCase {
     func testInitializers() throws {
         var client: OAuth2Client!
         
-        client = try OAuth2Client(domain: "example.com",
-                                  clientId: "abc123",
-                                  scope: "openid profile")
+        client = try OAuth2Client(.init(domain: "example.com",
+                                        clientId: "abc123",
+                                        scope: "openid profile"))
         XCTAssertEqual(client.configuration, .init(issuerURL: URL(string: "https://example.com")!,
                                                    clientId: "abc123",
                                                    scope: "openid profile",
@@ -69,11 +69,11 @@ final class OAuth2ClientTests: XCTestCase {
                                                    clientId: "abc123",
                                                    scope: "openid profile",
                                                    authentication: .none))
-
-        client = try OAuth2Client(domain: "example.com",
-                                  clientId: "abc123",
-                                  scope: "openid profile",
-                                  authentication: .clientSecret("supersecret"))
+        
+        client = try OAuth2Client(.init(domain: "example.com",
+                                        clientId: "abc123",
+                                        scope: "openid profile",
+                                        authentication: .clientSecret("supersecret")))
         XCTAssertEqual(client.configuration, .init(issuerURL: URL(string: "https://example.com")!,
                                                    clientId: "abc123",
                                                    scope: "openid profile",

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -1,3 +1,15 @@
+//
+// Copyright (c) 2024-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
 import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
@@ -78,17 +90,6 @@ final class OAuth2ClientTests: XCTestCase {
                                                    clientId: "abc123",
                                                    scope: "openid profile",
                                                    authentication: .clientSecret("supersecret")))
-    }
-    
-    func testConfiguration() throws {
-        XCTAssertNotEqual(try OAuth2Client.Configuration(domain: "example.com",
-                                                         clientId: "abc123",
-                                                         scope: "openid profile",
-                                                         authentication: .none),
-                          try OAuth2Client.Configuration(domain: "example.com",
-                                                         clientId: "abc123",
-                                                         scope: "openid profile",
-                                                         authentication: .clientSecret("supersecret")))
     }
     
     func testClientAuthentication() throws {

--- a/Tests/AuthFoundationTests/PropertyListConfigurationTests.swift
+++ b/Tests/AuthFoundationTests/PropertyListConfigurationTests.swift
@@ -23,7 +23,7 @@ final class PropertyListConfigurationTests: XCTestCase {
         let config = try PropertyListConfiguration(plist: url)
         XCTAssertEqual(config.issuerURL.absoluteString, "https://myapp.example.com/oauth2/default")
         XCTAssertEqual(config.clientId, "0oaasdf1234")
-        XCTAssertEqual(config.scope, "openid profile offline_access")
+        XCTAssertEqual(config.scope, ["openid", "profile", "offline_access"])
         XCTAssertEqual(config.redirectUri?.absoluteString, "com.example:/callback")
         XCTAssertEqual(config.logoutRedirectUri?.absoluteString, "com.example:/")
         XCTAssertEqual(config.additionalParameters?.mapValues(\.stringValue), [
@@ -36,7 +36,7 @@ final class PropertyListConfigurationTests: XCTestCase {
         let config = try PropertyListConfiguration(plist: url)
         XCTAssertEqual(config.issuerURL.absoluteString, "https://myapp.example.com/oauth2/default")
         XCTAssertEqual(config.clientId, "0oaasdf1234")
-        XCTAssertEqual(config.scope, "openid profile offline_access")
+        XCTAssertEqual(config.scope, ["openid", "profile", "offline_access"])
         XCTAssertEqual(config.redirectUri?.absoluteString, "com.example:/callback")
         XCTAssertEqual(config.logoutRedirectUri?.absoluteString, "com.example:/")
         XCTAssertEqual(config.additionalParameters?.mapValues(\.stringValue), [

--- a/Tests/AuthFoundationTests/TokenTests.swift
+++ b/Tests/AuthFoundationTests/TokenTests.swift
@@ -207,16 +207,16 @@ final class TokenTests: XCTestCase {
         XCTAssertEqual(token.id, "1834AF8D-BC97-4CCE-876F-300314784D5B")
         XCTAssertEqual(token.accessToken, JWT.mockAccessToken)
         XCTAssertEqual(token.idToken?.rawValue, JWT.mockIDToken)
-        XCTAssertEqual(token.scope, "profile offline_access openid")
+        XCTAssertEqual(token.scope, ["profile", "offline_access", "openid"])
         XCTAssertEqual(token.expiresIn, 3600)
         XCTAssertEqual(token.refreshToken, "refresh-kl2QWaYgyHaLkCdc6exjsowP9KUTW1ilAWC")
         XCTAssertEqual(token.deviceSecret, "device_lh4nMHgcUWLJIVgkcbQwnnSI2F8JMwNshLoa")
         XCTAssertEqual(token.issuedAt?.timeIntervalSinceReferenceDate, 744576826.0011461)
-        XCTAssertEqual(token.context.configuration.scope, "openid profile offline_access")
+        XCTAssertEqual(token.context.configuration.scope, ["openid", "profile", "offline_access"])
         XCTAssertEqual(token.context.configuration.redirectUri?.absoluteString, "com.example:/callback")
         XCTAssertEqual(token.context, .init(configuration: .init(issuerURL: try XCTUnwrap(URL(string: "https://example.com/oauth2/default")),
                                                                  clientId: "0oatheclientid",
-                                                                 scope: "openid profile offline_access",
+                                                                 scope: ["openid", "profile", "offline_access"],
                                                                  redirectUri: URL(string: "com.example:/callback"),
                                                                  authentication: .none),
                                             clientSettings: nil))

--- a/Tests/OktaDirectAuthTests/DirectAuthenticationFlowTests.swift
+++ b/Tests/OktaDirectAuthTests/DirectAuthenticationFlowTests.swift
@@ -94,8 +94,7 @@ final class DirectAuthenticationFlowTests: XCTestCase {
         let wait = expectation(description: "run step")
         let token = Token.mockToken()
         let factor = TestFactor(result: .success(.success(token)), exception: nil)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
 
         flow.runStep(with: factor) { result in
             XCTAssertEqual(result, .success(.success(token)))
@@ -111,8 +110,7 @@ final class DirectAuthenticationFlowTests: XCTestCase {
 
         let wait = expectation(description: "run step")
         let factor = TestFactor(result: .failure(.pollingTimeoutExceeded), exception: nil)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         flow.runStep(with: factor) { result in
             XCTAssertEqual(result, .failure(.pollingTimeoutExceeded))
             wait.fulfill()
@@ -127,8 +125,7 @@ final class DirectAuthenticationFlowTests: XCTestCase {
 
         let wait = expectation(description: "run step")
         let factor = TestFactor(result: nil, exception: APIClientError.invalidRequestData)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         flow.runStep(with: factor) { result in
             XCTAssertEqual(result, .failure(.network(error: .invalidRequestData)))
             wait.fulfill()

--- a/Tests/OktaDirectAuthTests/FactorStepHandlerTests.swift
+++ b/Tests/OktaDirectAuthTests/FactorStepHandlerTests.swift
@@ -50,8 +50,7 @@ final class FactorStepHandlerTests: XCTestCase {
                                    loginHint: String?,
                                    bodyParams: [String: String]) throws
     {
-        let context = DirectAuthenticationFlow.Context(acrValues: nil,
-                                                       intent: .signIn)
+        let context = DirectAuthenticationFlow.Context()
         flow.context = context
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
@@ -77,7 +76,7 @@ final class FactorStepHandlerTests: XCTestCase {
             loginHint: "jane.doe@example.com",
             bodyParams: [
                 "client_id": client.configuration.clientId,
-                "scope": client.configuration.scope,
+                "scope": client.configuration.$scope.rawValue,
                 "grant_type": "password",
                 "username": "jane.doe@example.com",
                 "password": "foo",
@@ -91,7 +90,7 @@ final class FactorStepHandlerTests: XCTestCase {
             loginHint: "jane.doe@example.com",
             bodyParams: [
                 "client_id": client.configuration.clientId,
-                "scope": client.configuration.scope,
+                "scope": client.configuration.$scope.rawValue,
                 "grant_type": "urn:okta:params:oauth:grant-type:otp",
                 "login_hint": "jane.doe@example.com",
                 "otp": "123456",
@@ -105,7 +104,7 @@ final class FactorStepHandlerTests: XCTestCase {
             loginHint: nil,
             bodyParams: [
                 "client_id": client.configuration.clientId,
-                "scope": client.configuration.scope,
+                "scope": client.configuration.$scope.rawValue,
                 "grant_type": "http://auth0.com/oauth/grant-type/mfa-otp",
                 "otp": "123456",
                 "grant_types_supported": "password urn:okta:params:oauth:grant-type:oob urn:okta:params:oauth:grant-type:otp http://auth0.com/oauth/grant-type/mfa-oob http://auth0.com/oauth/grant-type/mfa-otp urn:okta:params:oauth:grant-type:webauthn urn:okta:params:oauth:grant-type:mfa-webauthn",
@@ -116,8 +115,7 @@ final class FactorStepHandlerTests: XCTestCase {
     func assertOOBStepHandler<T: AuthenticationFactor>(factor: T,
                                                        loginHint: String?) throws
     {
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: loginHint,
@@ -152,8 +150,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
         
         let factor = PrimaryFactor.password("SuperSecret")
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -188,8 +185,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           statusCode: 400)
         
         let factor = PrimaryFactor.password("SuperSecret")
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -228,8 +224,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
         
         let factor = PrimaryFactor.oob(channel: .push)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -265,8 +260,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
 
         let factor = PrimaryFactor.oob(channel: .push)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -325,8 +319,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
 
         let factor = PrimaryFactor.oob(channel: .push)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -359,8 +352,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           statusCode: 400)
         
         let factor = PrimaryFactor.oob(channel: .push)
-        flow.context = .init(acrValues: nil,
-                             intent: .signIn)
+        flow.context = .init()
         let handler = try factor.stepHandler(flow: flow,
                                              openIdConfiguration: openIdConfiguration,
                                              loginHint: "jane.doe@example.com",
@@ -398,8 +390,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
 
         let factor = SecondaryFactor.oob(channel: .push)
-        var context = DirectAuthenticationFlow.Context(acrValues: nil,
-                                                       intent: .signIn)
+        var context = DirectAuthenticationFlow.Context()
         context.currentStatus = .mfaRequired(.init(supportedChallengeTypes: nil,
                                                    mfaToken: "abcd1234"))
         flow.context = context
@@ -438,8 +429,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
 
         let factor = SecondaryFactor.oob(channel: .push)
-        var context = DirectAuthenticationFlow.Context(acrValues: nil,
-                                                       intent: .signIn)
+        var context = DirectAuthenticationFlow.Context()
         context.currentStatus = .mfaRequired(.init(supportedChallengeTypes: nil,
                                                    mfaToken: "abcd1234"))
         flow.context = context
@@ -491,8 +481,7 @@ final class FactorStepHandlerTests: XCTestCase {
                           data: try data(from: .module, for: "token", in: "MockResponses"))
 
         let factor = SecondaryFactor.oob(channel: .push)
-        var context = DirectAuthenticationFlow.Context(acrValues: nil,
-                                                       intent: .signIn)
+        var context = DirectAuthenticationFlow.Context()
         context.currentStatus = .mfaRequired(.init(supportedChallengeTypes: nil,
                                                    mfaToken: "abcd1234"))
         flow.context = context

--- a/Tests/OktaDirectAuthTests/RequestTests.swift
+++ b/Tests/OktaDirectAuthTests/RequestTests.swift
@@ -33,8 +33,7 @@ final class RequestTests: XCTestCase {
                         clientConfiguration: .init(issuerURL: issuer,
                                                    clientId: "theClientId",
                                                    scope: "openid profile"),
-                        context: .init(acrValues: nil,
-                                       intent: .signIn),
+                        context: .init(),
                         factor: DirectAuthenticationFlow.PrimaryFactor.password("password123"))
         XCTAssertEqual(request.bodyParameters?.stringComponents,
                        [
@@ -49,8 +48,7 @@ final class RequestTests: XCTestCase {
                         clientConfiguration: .init(issuerURL: issuer,
                                                    clientId: "theClientId",
                                                    scope: "openid profile"),
-                        context: .init(acrValues: ["urn:foo:bar", "urn:baz:boo"],
-                                       intent: .signIn),
+                        context: .init(acrValues: ["urn:foo:bar", "urn:baz:boo"]),
                         factor: DirectAuthenticationFlow.PrimaryFactor.password("password123"))
         XCTAssertEqual(request.bodyParameters?.stringComponents,
                        [
@@ -67,8 +65,7 @@ final class RequestTests: XCTestCase {
                                                    clientId: "theClientId",
                                                    scope: "openid profile",
                                                    authentication: .clientSecret("supersecret")),
-                        context: .init(acrValues: nil,
-                                       intent: .signIn),
+                        context: .init(),
                         factor: DirectAuthenticationFlow.PrimaryFactor.password("password123"))
         XCTAssertEqual(request.bodyParameters?.stringComponents,
                        [
@@ -84,8 +81,7 @@ final class RequestTests: XCTestCase {
                         clientConfiguration: .init(issuerURL: issuer,
                                                    clientId: "theClientId",
                                                    scope: "openid profile"),
-                        context: .init(acrValues: nil,
-                                       intent: .recovery),
+                        context: .init(intent: .recovery),
                         factor: DirectAuthenticationFlow.PrimaryFactor.otp(code: "123456"))
         XCTAssertEqual(request.bodyParameters?.stringComponents,
                        [
@@ -105,8 +101,7 @@ final class RequestTests: XCTestCase {
                             clientConfiguration: .init(issuerURL: issuer,
                                                        clientId: "theClientId",
                                                        scope: "openid profile"),
-                            context: .init(acrValues: nil,
-                                           intent: .signIn),
+                            context: .init(),
                             loginHint: "user@example.com",
                             channelHint: .push,
                             challengeHint: .oob)
@@ -124,8 +119,7 @@ final class RequestTests: XCTestCase {
                                                        clientId: "theClientId",
                                                        scope: "openid profile",
                                                        authentication: .clientSecret("supersecret")),
-                            context: .init(acrValues: nil,
-                                           intent: .signIn),
+                            context: .init(),
                             loginHint: "user@example.com",
                             channelHint: .push,
                             challengeHint: .oob)
@@ -147,8 +141,7 @@ final class RequestTests: XCTestCase {
                             clientConfiguration: .init(issuerURL: issuer,
                                                        clientId: "theClientId",
                                                        scope: "openid profile"),
-                            context: .init(acrValues: nil,
-                                           intent: .signIn),
+                            context: .init(),
                             mfaToken: "abcd123",
                             challengeTypesSupported: [.password, .oob])
         XCTAssertEqual(request.bodyParameters?.stringComponents,
@@ -164,8 +157,7 @@ final class RequestTests: XCTestCase {
                                                        clientId: "theClientId",
                                                        scope: "openid profile",
                                                        authentication: .clientSecret("supersecret")),
-                            context: .init(acrValues: nil,
-                                           intent: .signIn),
+                            context: .init(),
                             mfaToken: "abcd123",
                             challengeTypesSupported: [.password, .oob])
         XCTAssertEqual(request.bodyParameters?.stringComponents,

--- a/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/AuthorizationCodeFlowSuccessTests.swift
@@ -123,7 +123,7 @@ final class AuthorizationCodeFlowSuccessTests: XCTestCase {
             XCTAssertNil(error)
         }
 
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(delegate.token)
         XCTAssertTrue(delegate.finished)
@@ -179,7 +179,7 @@ final class AuthorizationCodeFlowSuccessTests: XCTestCase {
             XCTAssertNil(error)
         }
 
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(token)
         
@@ -223,7 +223,7 @@ final class AuthorizationCodeFlowSuccessTests: XCTestCase {
         // Exchange code
         let token = try await flow.resume(with: URL(string: "com.example:/callback?code=ABCEasyAs123&state=ABC123")!)
         
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(token)
     }

--- a/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowErrorTests.swift
+++ b/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowErrorTests.swift
@@ -126,7 +126,7 @@ final class DeviceAuthorizationFlowErrorTests: XCTestCase {
             XCTAssertNil(error)
         }
 
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(token)
     }

--- a/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/DeviceAuthorizationFlowSuccessTests.swift
@@ -82,7 +82,7 @@ final class DeviceAuthorizationFlowSuccessTests: XCTestCase {
         waitForExpectations(timeout: 5) { error in
             XCTAssertNil(error)
         }
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(delegate.token)
         XCTAssertTrue(delegate.finished)
@@ -132,7 +132,7 @@ final class DeviceAuthorizationFlowSuccessTests: XCTestCase {
             XCTAssertNil(error)
         }
 
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(token)
     }
@@ -154,7 +154,7 @@ final class DeviceAuthorizationFlowSuccessTests: XCTestCase {
         // Exchange code
         let token = try await flow.resume()
 
-        XCTAssertNil(flow.context)
+        XCTAssertNotNil(flow.context)
         XCTAssertFalse(flow.isAuthenticating)
         XCTAssertNotNil(token)
     }

--- a/Tests/OktaOAuth2Tests/JWTAuthorizationFlowTests.swift
+++ b/Tests/OktaOAuth2Tests/JWTAuthorizationFlowTests.swift
@@ -123,7 +123,7 @@ final class JWTAuthorizationFlowTests: XCTestCase {
         flow.start(with: jwt) { result in
             switch result {
             case .success:
-                XCTAssertFalse(self.flow.isAuthenticating)
+                XCTAssertTrue(self.flow.isAuthenticating)
                 
                 authorizeExpectation.fulfill()
             case .failure(let error):

--- a/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
+++ b/Tests/OktaOAuth2Tests/OAuth2ClientTests.swift
@@ -90,7 +90,7 @@ final class OAuth2ClientTests: XCTestCase {
         XCTAssertEqual(token?.accessToken, JWT.mockAccessToken)
         XCTAssertEqual(token?.refreshToken, "therefreshtoken")
         XCTAssertNotNil(token?.idToken)
-        XCTAssertEqual(token?.scope, "openid profile offline_access")
+        XCTAssertEqual(token?.scope, ["openid", "profile", "offline_access"])
     }
     
     func testExchangeFailed() throws {

--- a/Tests/OktaOAuth2Tests/SessionLogoutFlowFailureTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionLogoutFlowFailureTests.swift
@@ -60,8 +60,8 @@ class SessionLogoutFlowFailureTests: XCTestCase {
         wait(for: [resumeExpection], timeout: 1)
         
         XCTAssertFalse(flow.inProgress)
-        XCTAssertNil(flow.context)
-        XCTAssertNotEqual(flow.context, context)
+        XCTAssertNotNil(flow.context)
+        XCTAssertEqual(flow.context, context)
         XCTAssertNil(flow.context?.logoutURL)
         
         XCTAssertNil(delegate.url)
@@ -90,8 +90,8 @@ class SessionLogoutFlowFailureTests: XCTestCase {
         wait(for: [resumeExpection], timeout: 1)
 
         XCTAssertFalse(flow.inProgress)
-        XCTAssertNil(flow.context)
-        XCTAssertNotEqual(flow.context, context)
+        XCTAssertNotNil(flow.context)
+        XCTAssertEqual(flow.context, context)
         XCTAssertNil(flow.context?.logoutURL)
     }
 }

--- a/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
+++ b/Tests/OktaOAuth2Tests/SessionLogoutFlowSuccessTests.swift
@@ -123,7 +123,8 @@ final class SessionLogoutFlowSuccessTests: XCTestCase {
         
         wait(for: [resumeExpection], timeout: 1)
 
-        XCTAssertNil(flow.context)
+        let newContext = try XCTUnwrap(flow.context)
+        XCTAssertNotEqual(newContext.logoutURL, context.logoutURL)
         XCTAssertFalse(flow.inProgress)
     }
 
@@ -165,7 +166,8 @@ final class SessionLogoutFlowSuccessTests: XCTestCase {
         
         let logoutUrl = try await flow.start(with: context)
         
-        XCTAssertNotEqual(flow.context, context)
+        let newContext = try XCTUnwrap(flow.context)
+        XCTAssertNotEqual(newContext.logoutURL, context.logoutURL)
         XCTAssertEqual(logoutUrl.absoluteString, """
                             https://example.okta.com/oauth2/v1/logout\
                             ?client_id=clientId\

--- a/Tests/WebAuthenticationUITests/WebAuthenticationInitializerTests.swift
+++ b/Tests/WebAuthenticationUITests/WebAuthenticationInitializerTests.swift
@@ -31,7 +31,7 @@ class WebAuthenticationInitializerTests: XCTestCase {
                                          logoutRedirectUri: logoutRedirectUri,
                                          additionalParameters: ["foo": "bar"])
         XCTAssertEqual(auth.signInFlow.client.configuration.clientId, "client_id")
-        XCTAssertEqual(auth.signInFlow.client.configuration.scope, "openid profile")
+        XCTAssertEqual(auth.signInFlow.client.configuration.scope, ["openid", "profile"])
         XCTAssertTrue(auth.signInFlow.client === auth.signOutFlow?.client)
         XCTAssertEqual(auth.signInFlow.additionalParameters?.stringComponents, ["foo": "bar"])
         XCTAssertEqual(auth.signOutFlow?.additionalParameters?.stringComponents, ["foo": "bar"])


### PR DESCRIPTION
- Introduces a `ClaimCollection` type to map whitespace-separated claim values to arrays
- Update `scope` values to be arrays instead of a string, [as discussed in another pull request](https://github.com/okta/okta-mobile-swift/pull/214#discussion_r1940009762).
- Normalize `acrValues` to use ClaimCollection, and make them optional
- Clean up documentation & nuances from the previous PR