### PR TITLE
Ensure Keychain SecItemDelete is not called with unsupported attributes

### DIFF
--- a/Sources/AuthFoundation/Security/Internal/Keychain+Extensions.swift
+++ b/Sources/AuthFoundation/Security/Internal/Keychain+Extensions.swift
@@ -47,6 +47,16 @@ fileprivate let _invalidDeleteQueryKeys = [
     kSecReturnPersistentRef,
 ].map { $0 as String }
 
+extension Keychain {
+    static let compositePrimaryKeyAttributes: [String] = [
+        kSecClass as String,
+        kSecAttrAccessGroup as String,
+        kSecAttrAccount as String,
+        kSecAttrService as String,
+        kSecAttrSynchronizable as String,
+    ]
+}
+
 extension KeychainGettable {
     var getQuery: [String: Any] {
         var result = self.query

--- a/Sources/AuthFoundation/Security/Keychain.swift
+++ b/Sources/AuthFoundation/Security/Keychain.swift
@@ -82,6 +82,8 @@ public struct Keychain {
             }
 
             let implementation = Keychain.implementation.wrappedValue
+
+            let deleteQuery = self.deleteQuery.filter { Keychain.compositePrimaryKeyAttributes.contains($0.key) }
             implementation.deleteItem(deleteQuery as CFDictionary)
 
             var ref: AnyObject?

--- a/Sources/AuthFoundation/Security/Keychain.swift
+++ b/Sources/AuthFoundation/Security/Keychain.swift
@@ -82,7 +82,7 @@ public struct Keychain {
             }
 
             let implementation = Keychain.implementation.wrappedValue
-            implementation.deleteItem(cfDictionary as CFDictionary)
+            implementation.deleteItem(deleteQuery as CFDictionary)
 
             var ref: AnyObject?
             let status = implementation.addItem(cfDictionary as CFDictionary, &ref)

--- a/Tests/AuthFoundationTests/KeychainTests.swift
+++ b/Tests/AuthFoundationTests/KeychainTests.swift
@@ -79,14 +79,8 @@ final class KeychainTests: XCTestCase {
         XCTAssertEqual(mock.operations[0], .init(action: .delete, query: [
             "acct": "testItemSave()",
             "class": "genp",
-            "desc": "Description",
-            "gena": genericData,
-            "labl": "Label",
-            "pdmn": "cku",
-            "nleg": 1,
             "sync": 1,
             "svce": "KeychainTests.swift",
-            "v_Data": value
         ], attributes: nil))
         XCTAssertEqual(mock.operations[1], .init(action: .add, query: query, attributes: nil))
 

--- a/Tests/AuthFoundationTests/KeychainTests.swift
+++ b/Tests/AuthFoundationTests/KeychainTests.swift
@@ -75,8 +75,19 @@ final class KeychainTests: XCTestCase {
                                  generic: genericData,
                                  value: value)
         try item.save()
-        
-        XCTAssertEqual(mock.operations[0], .init(action: .delete, query: query, attributes: nil))
+
+        XCTAssertEqual(mock.operations[0], .init(action: .delete, query: [
+            "acct": "testItemSave()",
+            "class": "genp",
+            "desc": "Description",
+            "gena": genericData,
+            "labl": "Label",
+            "pdmn": "cku",
+            "nleg": 1,
+            "sync": 1,
+            "svce": "KeychainTests.swift",
+            "v_Data": value
+        ], attributes: nil))
         XCTAssertEqual(mock.operations[1], .init(action: .add, query: query, attributes: nil))
 
         // Test failed save
@@ -151,15 +162,6 @@ final class KeychainTests: XCTestCase {
     }
     
     func testSearchList() throws {
-        let query = [
-            "acct": "testSearchList()",
-            "class": "genp",
-            "m_Limit": "m_LimitAll",
-            "r_Attributes": 1,
-            "r_Ref": 1,
-            "svce": "KeychainTests.swift"
-        ] as CFDictionary
-
         let result = [[
             "tomb": 0,
             "svce": "KeychainTests.swift",
@@ -175,14 +177,41 @@ final class KeychainTests: XCTestCase {
             "UUID": UUID().uuidString
         ]] as CFArray
         mock.expect(noErr, result: result)
+        mock.expect(noErr)
+        mock.expect(noErr)
 
         let search = Keychain.Search(account: #function,
-                                     service: serviceName,
                                      accessGroup: nil)
         let searchResults = try search.list()
-        
-        XCTAssertEqual(mock.operations[0], .init(action: .copy, query: query, attributes: nil))
+
+        // Delete an individual search result
+        try searchResults.first?.delete()
+
+        // Delete all items matching a search
+        try search.delete()
+
+        XCTAssertEqual(mock.operations[0], .init(action: .copy, query: [
+            "acct": "testSearchList()",
+            "class": "genp",
+            "m_Limit": "m_LimitAll",
+            "r_Attributes": 1,
+            "r_Ref": 1,
+        ], attributes: nil))
         XCTAssertEqual(searchResults.first?.account, "testSearchList()")
+
+        // Check search result delete
+        XCTAssertEqual(mock.operations[1], .init(action: .delete, query: [
+            "acct": "testSearchList()",
+            "class": "genp",
+            "svce": "KeychainTests.swift",
+            "agrp": "com.okta.sample.app",
+        ] as CFDictionary, attributes: nil))
+
+        // Check search delete
+        XCTAssertEqual(mock.operations[2], .init(action: .delete, query: [
+            "acct": "testSearchList()",
+            "class": "genp",
+        ] as CFDictionary, attributes: nil))
     }
     
     func testSearchGet() throws {


### PR DESCRIPTION
Under some circumstances, requests to delete a Keychain item could result in calls that used invalid request attributes / filters, or includes too many arguments that prevents old values from being deleted.