### PR TITLE
Fix import statements for other platforms

### DIFF
--- a/Samples/DirectAuthSignIn/UITests/Pages/SignInScreen.swift
+++ b/Samples/DirectAuthSignIn/UITests/Pages/SignInScreen.swift
@@ -95,7 +95,7 @@ class SignInScreen: Screen {
             if let fieldValue = field.value as? String,
                !fieldValue.isEmpty
             {
-                usleep(useconds_t(1000)) // Wait for the field to be selected
+                Thread.sleep(forTimeInterval: 0.1) // Wait for the field to be selected
                 field.tap(withNumberOfTaps: 3, numberOfTouches: 1)
             }
             

--- a/Samples/Shared/Common/Testing/Screen+Extensions.swift
+++ b/Samples/Shared/Common/Testing/Screen+Extensions.swift
@@ -71,10 +71,10 @@ extension WebLogin where Self: Screen {
                 _ = app.keyboards.firstMatch.waitForExistence(timeout: .standard)
                 
                 if !fieldValue.isEmpty {
-                    usleep(useconds_t(1000)) // Wait for the field to be selected
+                    Thread.sleep(forTimeInterval: 0.1) // Wait for the field to be selected
                     field.tap(withNumberOfTaps: 3, numberOfTouches: 1)
                     field.typeText("")
-                    usleep(useconds_t(500))
+                    Thread.sleep(forTimeInterval: 0.05)
                 }
                 
                 field.typeText(username)
@@ -143,7 +143,7 @@ extension WebLogin where Self: Screen {
             // Dismiss the password save reminder keyboard view in iOS 18+
             if app.otherElements["SFAutoFillInputView"].buttons["Not Now"].exists {
                 app.otherElements["SFAutoFillInputView"].buttons["Not Now"].tap()
-                usleep(useconds_t(500)) // Wait for the keyboard animation, since XCTest won't
+                Thread.sleep(forTimeInterval: 0.1) // Wait for the keyboard animation, since XCTest won't
                 field.tap()
                 _ = app.keyboards.firstMatch.waitForExistence(timeout: .standard)
             }

--- a/Sources/AuthFoundation/JWT/Protocols/JWKValidator.swift
+++ b/Sources/AuthFoundation/JWT/Protocols/JWKValidator.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if os(Linux) || os(Android)
 public typealias OSStatus = Int32
 #endif
 

--- a/Sources/AuthFoundation/Migration/SDKVersion.swift
+++ b/Sources/AuthFoundation/Migration/SDKVersion.swift
@@ -20,6 +20,10 @@ import UIKit
 import WatchKit
 #endif
 
+#if canImport(Android)
+import Android
+#endif
+
 private let deviceModel: String = {
     var system = utsname()
     uname(&system)
@@ -42,6 +46,8 @@ private let systemName: String = {
         return "macOS"
     #elseif os(Linux)
         return "linux"
+    #elseif os(Android)
+        return "android"
     #endif
 }()
 

--- a/Sources/AuthFoundation/Network/APIClient.swift
+++ b/Sources/AuthFoundation/Network/APIClient.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Network/APIClientError.swift
+++ b/Sources/AuthFoundation/Network/APIClientError.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Network/APIRequest.swift
+++ b/Sources/AuthFoundation/Network/APIRequest.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Network/Internal/FormDataExtensions.swift
+++ b/Sources/AuthFoundation/Network/Internal/FormDataExtensions.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Network/URLSessionProtocol.swift
+++ b/Sources/AuthFoundation/Network/URLSessionProtocol.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
@@ -25,7 +25,7 @@ public protocol URLSessionProtocol: Sendable {
 
 @_documentation(visibility: internal)
 extension URLSession: URLSessionProtocol {
-#if os(Linux)
+#if canImport(FoundationNetworking)
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         return try await withCheckedThrowingContinuation { continuation in
             let task = self.dataTask(with: request) { data, response, error in

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Requests/KeysRequest.swift
+++ b/Sources/AuthFoundation/Requests/KeysRequest.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Requests/OpenIdConfigurationRequest.swift
+++ b/Sources/AuthFoundation/Requests/OpenIdConfigurationRequest.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/User Management/Credential+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/Credential+Extensions.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/User Management/CredentialDataSource+Extensions.swift
+++ b/Sources/AuthFoundation/User Management/CredentialDataSource+Extensions.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/User Management/CredentialDataSource.swift
+++ b/Sources/AuthFoundation/User Management/CredentialDataSource.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
+++ b/Sources/AuthFoundation/Utilities/TimeCoordinator.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/AuthFoundation/Utilities/URL+InternalExtensions.swift
+++ b/Sources/AuthFoundation/Utilities/URL+InternalExtensions.swift
@@ -18,7 +18,7 @@ extension URL {
     @inlinable
     func appendingComponent(_ component: String) -> URL {
         // swiftlint:disable force_unwrapping
-        #if os(Linux)
+        #if canImport(FoundationNetworking)
         var components = URLComponents(url: self, resolvingAgainstBaseURL: true)!
         if !components.path.hasSuffix("/") {
             components.path.append("/")

--- a/Sources/OktaIdxAuth/Internal/Implementations/Version1/Requests/RemediationRequest.swift
+++ b/Sources/OktaIdxAuth/Internal/Implementations/Version1/Requests/RemediationRequest.swift
@@ -13,7 +13,7 @@
 import Foundation
 import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/APIClientTests.swift
+++ b/Tests/AuthFoundationTests/APIClientTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import AuthFoundation
 @testable import TestCommon
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/APIRetryTests.swift
+++ b/Tests/AuthFoundationTests/APIRetryTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import AuthFoundation
 @testable import TestCommon
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/AuthenticationFlowTests.swift
+++ b/Tests/AuthFoundationTests/AuthenticationFlowTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
+++ b/Tests/AuthFoundationTests/CredentialCoordinatorTests.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
@@ -108,7 +108,7 @@ final class UserCoordinatorTests: XCTestCase {
                                                 observing: [.defaultCredentialChanged])
 
             let credential = try TaskData.coordinator.store(token: token, tags: [:], security: [])
-            usleep(useconds_t(2000))
+            try await Task.sleep(delay: 0.02)
             await MainActor.run {
                 XCTAssertEqual(recorder.notifications.count, 1)
                 XCTAssertEqual(recorder.notifications.first?.object as? Credential, credential)
@@ -117,7 +117,7 @@ final class UserCoordinatorTests: XCTestCase {
             }
 
             TaskData.coordinator.default = nil
-            usleep(useconds_t(2000))
+            try await Task.sleep(delay: 0.02)
             await MainActor.run {
                 XCTAssertEqual(recorder.notifications.count, 1)
                 XCTAssertNil(recorder.notifications.first?.object)

--- a/Tests/AuthFoundationTests/CredentialRefreshTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRefreshTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
@@ -156,7 +156,7 @@ final class CredentialRefreshTests: XCTestCase, OAuth2ClientDelegate, @unchecked
             await fulfillment(of: [expect], timeout: 3.0)
 
             // Need to wait for the async notification dispatch
-            usleep(useconds_t(2000))
+            try await Task.sleep(delay: 0.02)
 
             XCTAssertEqual(notification.notifications.count, 2)
             let tokenNotification = try XCTUnwrap(notification.notifications(for: .tokenRefreshFailed).first)
@@ -308,7 +308,7 @@ final class CredentialRefreshTests: XCTestCase, OAuth2ClientDelegate, @unchecked
             // Stopping should prevent subsequent refreshes
             credential.automaticRefresh = false
 
-            sleep(1)
+            try await Task.sleep(delay: 1)
             XCTAssertEqual(urlSession.requests.count, 0)
         }
     }

--- a/Tests/AuthFoundationTests/CredentialRevokeTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRevokeTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/DefaultJWKValidatorTests.swift
+++ b/Tests/AuthFoundationTests/DefaultJWKValidatorTests.swift
@@ -47,7 +47,7 @@ final class DefaultJWKValidatorTests: XCTestCase {
 
         let jwt = try JWT(String.mockIdToken)
 
-        #if os(Linux)
+        #if canImport(FoundationNetworking)
         XCTAssertThrowsError(try validator.validate(token: jwt, using: jwks))
         #else
         XCTAssertNoThrow(try validator.validate(token: jwt, using: jwks))

--- a/Tests/AuthFoundationTests/DefaultTimeCoordinatorTests.swift
+++ b/Tests/AuthFoundationTests/DefaultTimeCoordinatorTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import AuthFoundation
 @testable import TestCommon
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/OAuth2ClientConfigurationTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientConfigurationTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @testable import TestCommon
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/AuthFoundationTests/OIDCLegacyMigratorTests.swift
+++ b/Tests/AuthFoundationTests/OIDCLegacyMigratorTests.swift
@@ -150,7 +150,7 @@ final class OIDCLegacyMigratorTests: XCTestCase {
             XCTAssertNoThrow(try migrator.migrate())
 
             // Need to wait for the async notification dispatch
-            usleep(useconds_t(2000))
+            Thread.sleep(forTimeInterval: 0.02)
 
             XCTAssertEqual(notificationRecorder.notifications.count, 1)
 

--- a/Tests/AuthFoundationTests/PKCETests.swift
+++ b/Tests/AuthFoundationTests/PKCETests.swift
@@ -23,7 +23,7 @@ final class PKCETests: XCTestCase {
         
         XCTAssertNotNil(pkce.codeVerifier)
         
-        #if os(Linux)
+        #if canImport(FoundationNetworking)
         XCTAssertEqual(pkce.codeVerifier, pkce.codeChallenge)
         XCTAssertEqual(pkce.method, .plain)
         #else

--- a/Tests/OktaIdxAuthTests/IDXClientRequestTests.swift
+++ b/Tests/OktaIdxAuthTests/IDXClientRequestTests.swift
@@ -17,7 +17,7 @@ import XCTest
 @testable import TestCommon
 #endif
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 
@@ -74,7 +74,7 @@ class IDXClientRequestTests: XCTestCase {
         XCTAssertEqual(data["client_id"], "clientId")
         XCTAssertEqual(data["scope"], "openid+profile")
         XCTAssertEqual(data["code_challenge"], pkce.codeChallenge)
-        #if os(Linux)
+        #if canImport(FoundationNetworking)
         XCTAssertEqual(data["code_challenge_method"], "plain")
         #else
         XCTAssertEqual(data["code_challenge_method"], "S256")

--- a/Tests/OktaIdxAuthTests/Mocks/URLSessionMock.swift
+++ b/Tests/OktaIdxAuthTests/Mocks/URLSessionMock.swift
@@ -16,7 +16,7 @@ import XCTest
 @testable import AuthFoundation
 @testable import OktaIdxAuth
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/TestCommon/MockApiClient.swift
+++ b/Tests/TestCommon/MockApiClient.swift
@@ -13,7 +13,7 @@
 import Foundation
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/TestCommon/MockApiRequest.swift
+++ b/Tests/TestCommon/MockApiRequest.swift
@@ -13,7 +13,7 @@
 import Foundation
 @testable import AuthFoundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/TestCommon/URLRequest+Extensions.swift
+++ b/Tests/TestCommon/URLRequest+Extensions.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Tests/TestCommon/URLSessionMock.swift
+++ b/Tests/TestCommon/URLSessionMock.swift
@@ -13,7 +13,7 @@
 import Foundation
 import XCTest
 
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 


### PR DESCRIPTION
The import statements to support Linux were overly specific to the OS, and needed to be adapted to switch on the availability of the specific framework / library required.

Furthermore, some environments don't expose the glibc functions like `sleep` and `usleep`, so those areas in the test code were updated to use Swift features instead (and making the timeouts a little longer in the process, due to CI flakiness).