### PR TITLE
Fix problems with BrowserSignin on tvOS

### DIFF
--- a/Sources/BrowserSignin/BrowserSignin.swift
+++ b/Sources/BrowserSignin/BrowserSignin.swift
@@ -140,14 +140,10 @@ public final class BrowserSignin {
         }
 
         async let authorizeUrl = signInFlow.start(with: context)
-        guard let provider = try await Self.providerFactory.createWebAuthenticationProvider(
+        let provider = try await Self.providerFactory.createWebAuthenticationProvider(
             for: self,
             from: window,
             options: options)
-        else {
-            throw BrowserSigninError.noCompatibleAuthenticationProviders
-        }
-        
         self.provider = provider
         
         let url = try await provider.open(authorizeUrl: authorizeUrl,
@@ -207,13 +203,10 @@ public final class BrowserSignin {
         }
 
         async let authorizeUrl = signOutFlow.start(with: context)
-        guard let provider = try await Self.providerFactory.createWebAuthenticationProvider(
+        let provider = try await Self.providerFactory.createWebAuthenticationProvider(
             for: self,
             from: window,
             options: options)
-        else {
-            throw BrowserSigninError.noCompatibleAuthenticationProviders
-        }
 
         self.provider = provider
         defer { self.provider = nil }
@@ -340,13 +333,13 @@ extension BrowserSignin: BrowserSignin.ProviderFactory {
     public nonisolated static func createWebAuthenticationProvider(
         for webAuth: BrowserSignin,
         from window: BrowserSignin.WindowAnchor?,
-        options: Option) throws -> (any BrowserSignin.Provider)?
+        options: Option) throws -> any BrowserSignin.Provider
     {
         if #available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *) {
             return try AuthenticationServicesProvider(from: window, usesEphemeralSession: options.contains(.ephemeralSession))
-        } else {
-            return nil
         }
+
+        throw BrowserSigninError.noCompatibleAuthenticationProviders
     }
 }
 

--- a/Sources/BrowserSignin/BrowserSignin.swift
+++ b/Sources/BrowserSignin/BrowserSignin.swift
@@ -27,7 +27,7 @@ public enum BrowserSigninError: Error {
     case cannotStartBrowserSession
     case cannotComposeAuthenticationURL
     case authenticationProvider(error: any Error)
-    case noAuthenticatorProviderResonse
+    case noAuthenticatorProviderResponse
     case serverError(_ error: OAuth2ServerError)
     case invalidRedirectScheme(_ scheme: String?)
     case userCancelledLogin(_ reason: String? = nil)
@@ -55,7 +55,6 @@ public enum BrowserSigninError: Error {
 ///
 ///  > Note: The use of HTTPS addresses within the redirect callback URI is limited by the availability of support within ASWebAuthenticationSession, which currently requires a minimum of iOS 17.4, macOS 14.4, watchOS 10.4, tvOS 17.4, or visionOS 1.1.
 @MainActor
-@available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *)
 public final class BrowserSignin {
     #if os(macOS)
     public typealias WindowAnchor = NSWindow
@@ -337,18 +336,20 @@ public final class BrowserSignin {
     var provider: (any BrowserSignin.Provider)?
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *)
 extension BrowserSignin: BrowserSignin.ProviderFactory {
     public nonisolated static func createWebAuthenticationProvider(
         for webAuth: BrowserSignin,
         from window: BrowserSignin.WindowAnchor?,
         options: Option) throws -> (any BrowserSignin.Provider)?
     {
-        try AuthenticationServicesProvider(from: window, usesEphemeralSession: options.contains(.ephemeralSession))
+        if #available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *) {
+            return try AuthenticationServicesProvider(from: window, usesEphemeralSession: options.contains(.ephemeralSession))
+        } else {
+            return nil
+        }
     }
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *)
 extension BrowserSignin {
     /// Asynchronously initiates authentication from the given window.
     /// - Parameters:

--- a/Sources/BrowserSignin/Internal/BrowserSigninError+Extensions.swift
+++ b/Sources/BrowserSignin/Internal/BrowserSigninError+Extensions.swift
@@ -13,11 +13,12 @@
 import Foundation
 import AuthenticationServices
 
-@available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *)
 extension BrowserSigninError: LocalizedError {
     init(_ error: any Error) {
         let nsError = error as NSError
-        if nsError.domain == ASWebAuthenticationSessionErrorDomain,
+        
+        if #available(iOS 13.0, macOS 10.15, tvOS 16.0, watchOS 7.0, visionOS 1.0, macCatalyst 13.0, *),
+           nsError.domain == ASWebAuthenticationSessionErrorDomain,
            nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue
         {
             self = .userCancelledLogin(nsError.localizedFailureReason)
@@ -105,7 +106,7 @@ extension BrowserSigninError: LocalizedError {
                                   comment: ""),
                 errorString)
 
-        case .noAuthenticatorProviderResonse:
+        case .noAuthenticatorProviderResponse:
             return NSLocalizedString("no_authenticator_provider_response",
                                      tableName: "BrowserSignin",
                                      bundle: .browserSignin,
@@ -113,9 +114,15 @@ extension BrowserSigninError: LocalizedError {
         case .genericError(message: let message):
             return message
         case .noSignOutFlowProvided:
-            return "FOO"
+            return NSLocalizedString("no_signout_flow_provided",
+                                     tableName: "BrowserSignin",
+                                     bundle: .browserSignin,
+                                     comment: "No signout flow provided")
         case .cannotStartBrowserSession:
-            return "FOO"
+            return NSLocalizedString("cannot_start_browser_session",
+                                     tableName: "BrowserSignin",
+                                     bundle: .browserSignin,
+                                     comment: "Cannot start browser session")
         }
     }
 }
@@ -129,7 +136,7 @@ extension BrowserSigninError: Equatable {
         case (.cannotComposeAuthenticationURL, .cannotComposeAuthenticationURL): return true
         case (.userCancelledLogin(let lhs), .userCancelledLogin(let rhs)):
             return lhs == rhs
-        case (.noAuthenticatorProviderResonse, .noAuthenticatorProviderResonse): return true
+        case (.noAuthenticatorProviderResponse, .noAuthenticatorProviderResponse): return true
         case (.missingIdToken, .missingIdToken): return true
         case (.authenticationProvider(error: let lhsValue), .authenticationProvider(error: let rhsValue)):
             return lhsValue as NSError == rhsValue as NSError

--- a/Sources/BrowserSignin/Providers/AuthenticationServicesProvider.swift
+++ b/Sources/BrowserSignin/Providers/AuthenticationServicesProvider.swift
@@ -147,7 +147,7 @@ final class AuthenticationServicesProvider: NSObject, BrowserSignin.Provider {
         }
         
         guard let url = url else {
-            return .failure(BrowserSigninError.noAuthenticatorProviderResonse)
+            return .failure(BrowserSigninError.noAuthenticatorProviderResponse)
         }
         
         return .success(url)

--- a/Sources/BrowserSignin/Providers/BrowserSigninProvider.swift
+++ b/Sources/BrowserSignin/Providers/BrowserSigninProvider.swift
@@ -40,9 +40,10 @@ extension BrowserSignin {
         ///   - window: The window anchor the sign-in is initiated from.
         ///   - options: The options used to control the sign in provider's behavior.
         /// - Returns: ``BrowserSignin/Provider`` that is capable of signing in, or `nil` if browser sign in is unsupported on this platform.
+        /// - Throws: ``BrowserSigninError/noCompatibleAuthenticationProviders`` if no provider could be found.
         nonisolated static func createWebAuthenticationProvider(
             for browserSignin: BrowserSignin,
             from window: BrowserSignin.WindowAnchor?,
-            options: BrowserSignin.Option) async throws -> (any Provider)?
+            options: BrowserSignin.Option) async throws -> any Provider
     }
 }

--- a/Sources/BrowserSignin/Resources/en.lproj/BrowserSignin.strings
+++ b/Sources/BrowserSignin/Resources/en.lproj/BrowserSignin.strings
@@ -10,3 +10,5 @@
 "no_scheme_defined" = "No URL scheme defined";
 "missing_id_token_description" = "Missing ID Token";
 "no_authenticator_provider_response" = "Authentication session returned neither a URL or an error";
+"no_signout_flow_provided" = "No sign out flow available";
+"cannot_start_browser_session" = "Cannot open a browser session";

--- a/Tests/BrowserSigninTests/AuthenticationServicesProviderTests.swift
+++ b/Tests/BrowserSigninTests/AuthenticationServicesProviderTests.swift
@@ -24,6 +24,7 @@ import CommonSupport
 @testable import BrowserSignin
 import AuthenticationServices
 
+@available(iOS 12.0, macCatalyst 13.0, macOS 10.15, tvOS 16.0, visionOS 1.0, watchOS 6.2, *)
 class MockAuthenticationServicesProviderSession: NSObject, @unchecked Sendable, AuthenticationServicesProviderSession {
     let url: URL
     let callbackURLScheme: String?
@@ -53,9 +54,12 @@ class MockAuthenticationServicesProviderSession: NSObject, @unchecked Sendable, 
         self.completionHandler = completionHandler
     }
 
+    #if os(iOS) || os(macOS) || os(visionOS) || targetEnvironment(macCatalyst)
     var presentationContextProvider: (any ASWebAuthenticationPresentationContextProviding)?
+    #endif
+
     var prefersEphemeralWebBrowserSession = false
-    
+
     var canStart: Bool = true
 
     func start() -> Bool {
@@ -83,7 +87,7 @@ class MockAuthenticationServicesProviderSession: NSObject, @unchecked Sendable, 
     }
 }
 
-@available(iOS 13.0, *)
+@available(iOS 12.0, macCatalyst 13.0, macOS 10.15, tvOS 16.0, visionOS 1.0, watchOS 6.2, *)
 class AuthenticationServicesProviderTests: XCTestCase {
     var provider: AuthenticationServicesProvider!
     let authorizeUrl = URL(string: "https://example.okta.com/oauth2/v1/authorize?client_id=clientId&redirect_uri=com.example:/callback&response_type=code&scope=openid%20profile&state=ABC123")
@@ -153,7 +157,7 @@ class AuthenticationServicesProviderTests: XCTestCase {
         MockAuthenticationServicesProviderSession.result.wrappedValue = nil
         let response = await XCTAssertThrowsErrorAsync(try await provider.open(authorizeUrl: authorizeUrl, redirectUri: redirectUri))
         
-        XCTAssertEqual(response as? BrowserSigninError, .noAuthenticatorProviderResonse)
+        XCTAssertEqual(response as? BrowserSigninError, .noAuthenticatorProviderResponse)
         XCTAssertNil(provider.authenticationSession)
     }
 }

--- a/Tests/BrowserSigninTests/BrowserSigninFlowTests.swift
+++ b/Tests/BrowserSigninTests/BrowserSigninFlowTests.swift
@@ -117,6 +117,7 @@ class BrowserSigninFlowTests: XCTestCase {
         XCTAssertEqual(redirectUri.absoluteString, "com.example:/logout")
     }
     
+    @available(iOS 12.0, macCatalyst 13.0, macOS 10.15, tvOS 16.0, visionOS 1.0, watchOS 6.2, *)
     func testCancel() async throws {
         let loginFlow = try AuthorizationCodeFlow(client: client,
                                                   additionalParameters: ["testName": name])

--- a/Tests/BrowserSigninTests/BrowserSigninMocks.swift
+++ b/Tests/BrowserSigninTests/BrowserSigninMocks.swift
@@ -43,7 +43,7 @@ struct BrowserSigninProviderFactoryMock: BrowserSignin.ProviderFactory {
     
     static func createWebAuthenticationProvider(for browserSignin: BrowserSignin,
                                                 from window: BrowserSignin.WindowAnchor?,
-                                                options: BrowserSignin.Option) async throws -> (any BrowserSignin.Provider)?
+                                                options: BrowserSignin.Option) async throws -> any BrowserSignin.Provider
     {
         let testName = browserSignin.signInFlow.additionalParameters?["testName"] as? String
 

--- a/Tests/BrowserSigninTests/BrowserSigninMocks.swift
+++ b/Tests/BrowserSigninTests/BrowserSigninMocks.swift
@@ -97,7 +97,7 @@ class BrowserSigninProviderMock: @unchecked Sendable, BrowserSignin.Provider {
             }
             throw error
         case nil:
-            throw BrowserSigninError.noAuthenticatorProviderResonse
+            throw BrowserSigninError.noAuthenticatorProviderResponse
         }
     }
     


### PR DESCRIPTION
Availability checks produced some errors under Xcode 26 on tvOS, and add missing descriptions for some new errors.