### PR TITLE
Add support for Pushed Authorization Requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,21 @@ orbs:
 executors:
   apple-ci-arm-medium:
     macos:
-      xcode: "16.2.0"
+      xcode: "26.2.0"
     resource_class: m4pro.medium
 
 commands:
   prepare-ios-simulator:
     steps:
       - macos/preboot-simulator:
-          version: "18.2"
+          version: "18.6"
           platform: "iOS"
           device: "iPhone 16 Pro Max"
 
   prepare-tvos-simulator:
     steps:
       - macos/preboot-simulator:
-          version: "18.2"
+          version: "18.5"
           platform: "tvOS"
           device: "Apple TV"
 

--- a/Sources/AuthFoundation/Responses/OpenIdConfiguration.swift
+++ b/Sources/AuthFoundation/Responses/OpenIdConfiguration.swift
@@ -77,6 +77,7 @@ extension OpenIdConfiguration {
     public var endSessionEndpoint: URL? { self[.endSessionEndpoint] }
     public var introspectionEndpoint: URL? { self[.introspectionEndpoint] }
     public var deviceAuthorizationEndpoint: URL? { self[.deviceAuthorizationEndpoint] }
+    public var pushedAuthorizationRequestEndpoint: URL? { self[.pushedAuthorizationRequestEndpoint] }
     public var registrationEndpoint: URL? { self[.registrationEndpoint] }
     public var revocationEndpoint: URL? { self[.revocationEndpoint] }
     public var userinfoEndpoint: URL? { self[.userinfoEndpoint] }

--- a/Sources/AuthFoundation/Responses/OpenIdProviderMetadata.swift
+++ b/Sources/AuthFoundation/Responses/OpenIdProviderMetadata.swift
@@ -35,6 +35,7 @@ extension OpenIdConfiguration {
         case userinfoSigningAlgValuesSupported          = "userinfo_signing_alg_values_supported"
         case userinfoEncryptionAlgValuesSupported       = "userinfo_encryption_alg_values_supported"
         case userinfoEncryptionEncValuesSupported       = "userinfo_encryption_enc_values_supported"
+        case pushedAuthorizationRequestEndpoint         = "pushed_authorization_request_endpoint"
         case requestObjectSigningAlgValuesSupported     = "request_object_signing_alg_values_supported"
         case requestObjectEncryptionAlgValuesSupported  = "request_object_encryption_alg_values_supported"
         case requestObjectEncryptionEncValuesSupported  = "request_object_encryption_enc_values_supported"

--- a/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow+Context.swift
+++ b/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow+Context.swift
@@ -94,7 +94,10 @@ extension AuthorizationCodeFlow {
                 authenticationURL = nil
             }
         }
-
+        
+        /// Utilize Pushed Authorization Requests (PAR) if supported by the Authorization Server.
+        public var pushedAuthorizationRequestEnabled: Bool = true
+        
         /// The current authentication URL, or `nil` if one has not yet been generated.
         public internal(set) var authenticationURL: URL?
         

--- a/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
@@ -168,7 +168,9 @@ public actor AuthorizationCodeFlow: AuthenticationFlow {
             let openIdConfiguration = try await client.openIdConfiguration()
 
             var parUrl: URL?
-            if let parRequestUrl = openIdConfiguration.pushedAuthorizationRequestEndpoint {
+            if context.pushedAuthorizationRequestEnabled,
+               let parRequestUrl = openIdConfiguration.pushedAuthorizationRequestEndpoint
+            {
                 let request = PushedAuthorizationRequest(url: parRequestUrl,
                                                          clientConfiguration: client.configuration,
                                                          additionalParameters: additionalParameters,

--- a/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
@@ -165,8 +165,32 @@ public actor AuthorizationCodeFlow: AuthenticationFlow {
 
         return try await withExpression {
             var context = context
-            let url = try self.createAuthenticationURL(from: try await client.openIdConfiguration().authorizationEndpoint,
-                                                       using: context)
+            let openIdConfiguration = try await client.openIdConfiguration()
+
+            var parUrl: URL?
+            if let parRequestUrl = openIdConfiguration.pushedAuthorizationRequestEndpoint {
+                let request = PushedAuthorizationRequest(url: parRequestUrl,
+                                                         clientConfiguration: client.configuration,
+                                                         additionalParameters: additionalParameters,
+                                                         context: context)
+                let response = try await request.send(to: client).result
+                var components = URLComponents(url: openIdConfiguration.authorizationEndpoint,
+                                               resolvingAgainstBaseURL: true)
+                components?.queryItems = [
+                    .init(name: "client_id", value: client.configuration.clientId),
+                    .init(name: "request_uri", value: response.requestUri),
+                ]
+                parUrl = components?.url
+            }
+            
+            let url: URL
+            if let parUrl {
+                url = parUrl
+            } else {
+                url = try createAuthenticationURL(from: openIdConfiguration.authorizationEndpoint,
+                                                  using: context)
+            }
+            
             context.authenticationURL = url
             _context = context
 

--- a/Sources/OAuth2Auth/Authentication/SessionTokenFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/SessionTokenFlow.swift
@@ -103,6 +103,9 @@ public actor SessionTokenFlow: AuthenticationFlow {
     public func start(with sessionToken: String,
                       context: Context = .init()) async throws -> Token
     {
+        var context = context
+        context.pushedAuthorizationRequestEnabled = false
+
         _isAuthenticating = true
         _context = context
 

--- a/Sources/OAuth2Auth/Internal/Requests/AuthorizationCodeFlow+Requests.swift
+++ b/Sources/OAuth2Auth/Internal/Requests/AuthorizationCodeFlow+Requests.swift
@@ -14,6 +14,25 @@ import Foundation
 import AuthFoundation
 
 extension AuthorizationCodeFlow {
+    struct PushedAuthorizationResponse: Codable {
+        let requestUri: String
+        let expiresIn: Int
+
+        enum CodingKeys: String, CodingKey {
+            case requestUri = "request_uri"
+            case expiresIn = "expires_in"
+        }
+    }
+    
+    struct PushedAuthorizationRequest: AuthenticationFlowRequest {
+        typealias Flow = AuthorizationCodeFlow
+        
+        let url: URL
+        let clientConfiguration: OAuth2Client.Configuration
+        let additionalParameters: [String: any APIRequestArgument]?
+        let context: Flow.Context
+    }
+
     struct TokenRequest: OAuth2TokenRequest, AuthenticationFlowRequest {
         typealias Flow = AuthorizationCodeFlow
 
@@ -59,3 +78,18 @@ extension AuthorizationCodeFlow.TokenRequest {
 }
 
 extension AuthorizationCodeFlow.TokenRequest: APIParsingContext {}
+
+extension AuthorizationCodeFlow.PushedAuthorizationRequest: APIRequest, APIRequestBody {
+    typealias ResponseType = AuthorizationCodeFlow.PushedAuthorizationResponse
+
+    var httpMethod: APIRequestMethod { .post }
+    var contentType: APIContentType? { .formEncoded }
+    var acceptsType: APIContentType? { .json }
+    var category: OAuth2APIRequestCategory { .authorization }
+    var bodyParameters: [String: any APIRequestArgument]? {
+        var result = additionalParameters ?? [:]
+        result.merge(clientConfiguration.parameters(for: category))
+        result.merge(context.parameters(for: category))
+        return result
+    }
+}


### PR DESCRIPTION
Introduce conditional support for Pushed Authorization Requests during the web redirect sign-in flow. If the PAR request is unable to compose an authorization URL it falls back to a traditional query-string approach.