### PR TITLE
Adapt CredentialActor to use a GCD-based serial queue to avoid mixing thread isolation patterns

### DIFF
--- a/Sources/AuthFoundation/Migration/SDKVersion.swift
+++ b/Sources/AuthFoundation/Migration/SDKVersion.swift
@@ -16,14 +16,6 @@ import Foundation
 import CommonSupport
 #endif
 
-#if canImport(UIKit)
-import UIKit
-#endif
-
-#if os(watchOS)
-import WatchKit
-#endif
-
 #if canImport(Android)
 import Android
 #endif
@@ -31,7 +23,11 @@ import Android
 private let deviceModel: String = {
     var system = utsname()
     uname(&system)
-    let model = withUnsafePointer(to: &system.machine.0) { ptr in
+    let model = withUnsafeBytes(of: &system.machine) { buf in
+        guard let ptr = buf.baseAddress?.assumingMemoryBound(to: CChar.self)
+        else {
+            return "unknown"
+        }
         return String(cString: ptr)
     }
     return model
@@ -52,22 +48,16 @@ private let systemName: String = {
         return "android"
     #elseif os(Linux)
         return "linux"
-    #elseif os(Android)
-        return "android"
+    #elseif os(Windows)
+        return "windows"
+    #else
+        return "unknown"
     #endif
 }()
 
 private let systemVersion: String = {
-    #if os(iOS) || os(tvOS) || (swift(>=5.10) && os(visionOS))
-    return MainActor.nonisolatedUnsafe {
-        UIDevice.current.systemVersion
-    }
-    #elseif os(watchOS)
-        return WKInterfaceDevice.current().systemVersion
-    #else
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
-    #endif
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
 }()
 
 /// Utility class that allows SDK components to register their name and version for use in HTTP User-Agent values.
@@ -101,20 +91,24 @@ public struct SDKVersion: Sendable {
     @discardableResult
     public static func register(sdk: SDKVersion) -> SDKVersion {
         lock.withLock {
-            guard _sdkVersions.filter({ $0.name == sdk.name }).isEmpty else {
-                return sdk
-            }
+            _register(sdk: sdk)
+        }
+    }
 
-            _sdkVersions.append(sdk)
-
-            let sdkVersionString = _sdkVersions
-                .sorted(by: { $0.name.rawValue < $1.name.rawValue })
-                .map(\.displayName)
-                .joined(separator: " ")
-            _userAgent = "\(sdkVersionString) \(systemName)/\(systemVersion) Device/\(deviceModel)"
-
+    private static func _register(sdk: SDKVersion) -> SDKVersion {
+        guard _sdkVersions.filter({ $0.name == sdk.name }).isEmpty else {
             return sdk
         }
+        
+        _sdkVersions.append(sdk)
+        
+        let sdkVersionString = _sdkVersions
+            .sorted(by: { $0.name.rawValue < $1.name.rawValue })
+            .map(\.displayName)
+            .joined(separator: " ")
+        _userAgent = "\(sdkVersionString) \(systemName)/\(systemVersion) Device/\(deviceModel)"
+        
+        return sdk
     }
 
     /// Convenience function used to register an SDK
@@ -122,15 +116,16 @@ public struct SDKVersion: Sendable {
     ///   - name: SDK name.
     ///   - versionString: SDK version.
     /// - Returns: The resulting SDKVersion object.
-    @inlinable
     @discardableResult
     public static func register(_ name: Name, version versionString: String) -> SDKVersion? {
-        let sdk = version(for: name) ?? register(sdk: SDKVersion(sdk: name, version: versionString))
-        guard sdk.version == versionString
-        else {
-            return nil
+        lock.withLock {
+            let sdk = _version(for: name) ?? _register(sdk: SDKVersion(sdk: name, version: versionString))
+            guard sdk.version == versionString
+            else {
+                return nil
+            }
+            return sdk
         }
-        return sdk
     }
 
     /// Returns the version information for the given SDK.
@@ -138,8 +133,12 @@ public struct SDKVersion: Sendable {
     /// - Returns: Version information for the given SDK name.
     public static func version(for sdkName: Name) -> SDKVersion? {
         lock.withLock {
-            _sdkVersions.first(where: { $0.name == sdkName })
+            _version(for: sdkName)
         }
+    }
+
+    private static func _version(for sdkName: Name) -> SDKVersion? {
+        _sdkVersions.first(where: { $0.name == sdkName })
     }
 
     // MARK: Private properties / methods

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -31,14 +31,14 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
         get {
             assert(SDKVersion.authFoundation != nil)
 
-            return withIsolationSync { @CredentialActor in
+            return CredentialActor.sync {
                 TaskData.coordinator.default
             }
         }
         set {
             assert(SDKVersion.authFoundation != nil)
 
-            withIsolationSync { @CredentialActor in
+            CredentialActor.sync {
                 TaskData.coordinator.default = newValue
             }
         }
@@ -48,7 +48,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     public static var allIDs: [String] {
         assert(SDKVersion.authFoundation != nil)
 
-        return withIsolationSync { @CredentialActor in
+        return CredentialActor.sync {
             TaskData.coordinator.allIDs
         } ?? []
     }
@@ -74,7 +74,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     public static func with(id: String, prompt: String? = nil, authenticationContext: (any TokenAuthenticationContext)? = nil) throws -> Credential? {
         assert(SDKVersion.authFoundation != nil)
 
-        return try withIsolationSyncThrowing { @CredentialActor in
+        return try CredentialActor.sync {
             try TaskData.coordinator.with(id: id,
                                           prompt: prompt,
                                           authenticationContext: authenticationContext)
@@ -102,7 +102,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     public static func find(where expression: @Sendable @escaping (Token.Metadata) -> Bool, prompt: String? = nil, authenticationContext: (any TokenAuthenticationContext)? = nil) throws -> [Credential] {
         assert(SDKVersion.authFoundation != nil)
 
-        return try withIsolationSyncThrowing { @CredentialActor in
+        return try CredentialActor.sync {
             try TaskData.coordinator.find(where: expression,
                                           prompt: prompt,
                                           authenticationContext: authenticationContext)
@@ -129,7 +129,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     ) throws -> Credential {
         assert(SDKVersion.authFoundation != nil)
 
-        return try withIsolationSyncThrowing { @CredentialActor in
+        return try CredentialActor.sync {
             try TaskData.coordinator.store(token: token, tags: tags, security: options)
         }
     }
@@ -181,7 +181,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
             throw CredentialError.missingCoordinator
         }
      
-        metadata = try withIsolationSyncThrowing { @CredentialActor in
+        metadata = try CredentialActor.sync {
             let metadata = try Token.Metadata(token: self.token, tags: tags)
             try coordinator.tokenStorage.setMetadata(metadata)
             return metadata
@@ -239,7 +239,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
             throw CredentialError.missingCoordinator
         }
 
-        try withIsolationSyncThrowing { @CredentialActor in
+        try CredentialActor.sync {
             try coordinator.remove(credential: self)
         }
     }
@@ -282,7 +282,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
         if let coordinator,
             shouldRemove(for: type)
         {
-            try withIsolationSyncThrowing { @CredentialActor in
+            try await CredentialActor.run {
                 try coordinator.remove(credential: self)
             }
         }
@@ -376,27 +376,28 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     nonisolated(unsafe) private var _metadata: Token.Metadata?
     var metadata: Token.Metadata {
         get {
-            lock.withLock {
-                if let metadata = _metadata {
-                    return metadata
-                }
-
-                let result: Token.Metadata
-
-                let id = id
-                if let coordinator,
-                   let metadata = withIsolationSync({
-                       try? await coordinator.tokenStorage.metadata(for: id)
-                   })
-                {
-                    result = metadata
-                } else {
-                    result = Token.Metadata(id: id)
-                }
-
-                _metadata = result
-                return result
+            // Return cached value under lock, if present
+            if let cached = lock.withLock({ _metadata }) {
+                return cached
             }
+
+            // Fetch from storage outside the lock to avoid both re-entrant
+            // lock access (self.id -> self.token -> lock) and holding the
+            // lock while blocking on withIsolationSync.
+            let result: Token.Metadata
+            let id = id
+            if let coordinator,
+               let metadata = CredentialActor.sync({
+                   try? coordinator.tokenStorage.metadata(for: id)
+               })
+            {
+                result = metadata
+            } else {
+                result = Token.Metadata(id: id)
+            }
+
+            lock.withLock { _metadata = result }
+            return result
         }
         set {
             lock.withLock {

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -50,7 +50,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
 
         return CredentialActor.sync {
             TaskData.coordinator.allIDs
-        } ?? []
+        }
     }
 
     /// The default grace interval used when refreshing tokens using ``Credential/refreshIfNeeded(graceInterval:completion:)`` or ``Credential/refreshIfNeeded(graceInterval:)``.

--- a/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
+++ b/Sources/AuthFoundation/User Management/Internal/CredentialCoordinatorImpl.swift
@@ -208,14 +208,14 @@ extension CredentialCoordinatorImpl: OAuth2ClientDelegate {
             return
         }
 
-        withIsolationSync {
-            do {
-                try await self.tokenStorage.replace(token: token.id,
-                                                    with: newToken,
-                                                    security: nil)
-            } catch {
-                print("Error happened refreshing: \(error)")
+        do {
+            try CredentialActor.sync {
+                try self.tokenStorage.replace(token: token.id,
+                                              with: newToken,
+                                              security: nil)
             }
+        } catch {
+            print("Error happened refreshing: \(error)")
         }
     }
 }

--- a/Sources/AuthFoundation/Utilities/AsyncUtilities.swift
+++ b/Sources/AuthFoundation/Utilities/AsyncUtilities.swift
@@ -35,16 +35,93 @@ extension Task where Success == Never, Failure == Never {
     }
 }
 
+private final class DispatchQueueExecutor: SerialExecutor {
+     private let queue: DispatchQueue
+
+     init(queue: DispatchQueue) {
+         self.queue = queue
+     }
+
+     func enqueue(_ job: UnownedJob) {
+         self.queue.async {
+             job.runSynchronously(on: self.asUnownedSerialExecutor())
+         }
+     }
+
+     func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+         UnownedSerialExecutor(ordinary: self)
+     }
+
+    func checkIsolated() {
+        dispatchPrecondition(condition: .onQueue(self.queue))
+    }
+}
+
+/// Strips `@CredentialActor` isolation from a closure's type signature.
+///
+/// Swift's type system treats `@CredentialActor () -> T` and `() -> T` as
+/// distinct types. When executing on the actor's serial GCD queue (via
+/// `queue.sync`), we are *semantically* within the actor's isolation domain
+/// — the custom ``DispatchQueueExecutor`` guarantees this, and its
+/// `checkIsolated()` method provides a runtime assertion.
+///
+/// However, the compiler can't statically verify that `queue.sync` provides
+/// the actor's isolation. There is currently no first-class Swift API to
+/// express "Trust me, I'm on this global actor's executor." Until an API exists,
+/// `unsafeBitCast` is used to reinterpret the closure type.
+///
+/// This is safe because:
+/// 1. The closure's ABI representation is identical with or without the
+///    `@CredentialActor` attribute — it only affects compile-time checking.
+/// 2. The ``sync`` guarantees execution on the
+///    actor's serial queue before invoking the result.
+@inline(__always)
+private nonisolated func stripIsolation<T>(
+    _ body: @CredentialActor @Sendable @escaping () throws -> T
+) -> @Sendable () throws -> T {
+    unsafeBitCast(body, to: (@Sendable () throws -> T).self)
+}
+
 /// Shared actor used to coordinate multithreaded interactions within the Credential storage subsystem.
 @globalActor
 @_documentation(visibility: private)
 public final actor CredentialActor {
     public static let shared = CredentialActor()
-    
+
+    private let queue = DispatchQueue(label: "com.okta.credential-actor")
+    private let executor: DispatchQueueExecutor
+
+    private init() {
+        self.executor = DispatchQueueExecutor(queue: queue)
+    }
+
+    nonisolated public var unownedExecutor: UnownedSerialExecutor {
+        executor.asUnownedSerialExecutor()
+    }
+
     /// Convenience for running a block within the context of the ``CredentialActor``.
     /// - Parameter body: Block to execute.
     /// - Returns: Result of the block.
     public static func run<T: Sendable>(_ body: @CredentialActor @Sendable () throws -> T) async rethrows -> T {
         try await body()
+    }
+
+    /// Synchronously executes a block on the ``CredentialActor``'s serial queue,
+    /// blocking the caller until completion.
+    ///
+    /// This dispatches directly to the actor's GCD queue using `DispatchQueue.sync`,
+    /// bypassing the Swift cooperative thread pool. This prevents deadlocks that can occur
+    /// when all cooperative threads are blocked by `DispatchGroup.wait()`.
+    ///
+    /// > Warning: This is intended for the exclusive use of synchronous use-cases that interact with the credential storage sub-system. It may be made public at some point, but is being kept `internal` until it is required.
+    ///
+    /// - Parameter body: Block to execute on the actor's serial queue.
+    /// - Returns: The result of the block.
+    /// - Throws: Any error thrown by the block.
+    nonisolated static func sync<T: Sendable>(_ body: @CredentialActor @Sendable @escaping () throws -> T) rethrows -> T {
+        let rawBody = stripIsolation(body)
+        return try shared.queue.sync {
+            try rawBody()
+        }
     }
 }

--- a/Tests/AuthFoundationTests/CredentialRevokeTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRevokeTests.swift
@@ -52,7 +52,7 @@ final class CredentialTests: XCTestCase {
 
 
     func testRemove() async throws {
-        XCTAssertNoThrow(try credential.remove())
+        try await credential.remove()
 
         let hasCredential = await coordinator.credentialDataSource.hasCredential(for: token)
         XCTAssertFalse(hasCredential)

--- a/Tests/AuthFoundationTests/CredentialRevokeTests.swift
+++ b/Tests/AuthFoundationTests/CredentialRevokeTests.swift
@@ -52,7 +52,7 @@ final class CredentialTests: XCTestCase {
 
 
     func testRemove() async throws {
-        try await credential.remove()
+        try credential.remove()
 
         let hasCredential = await coordinator.credentialDataSource.hasCredential(for: token)
         XCTAssertFalse(hasCredential)

--- a/Tests/AuthFoundationTests/CredentialThreadStarvationTests.swift
+++ b/Tests/AuthFoundationTests/CredentialThreadStarvationTests.swift
@@ -1,0 +1,230 @@
+//
+// Copyright (c) 2024-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+
+@testable import TestCommon
+@testable import AuthFoundation
+
+/// Tests that verify the CredentialActor's custom GCD-backed executor prevents
+/// cooperative thread pool starvation when synchronous bridges
+/// (withIsolationSync / withIsolationSyncThrowing) are called from async contexts.
+///
+/// ## Background
+/// Prior to the custom executor fix, `withIsolationSyncThrowing` used
+/// `DispatchGroup.wait()` to block the current thread while spawning a `Task`
+/// to execute `@CredentialActor`-isolated work. When the calling thread was part
+/// of the Swift cooperative pool (e.g. inside a `Task`), this could exhaust the
+/// pool and deadlock — the inner Task needed a cooperative thread to run, but
+/// all threads were blocked by `group.wait()`.
+///
+/// The fix gives `CredentialActor` a `DispatchQueue`-backed `SerialExecutor`,
+/// so actor-isolated work runs on GCD threads instead of the cooperative pool.
+final class CredentialThreadStarvationTests: XCTestCase {
+
+    var coordinator: MockCredentialCoordinator!
+
+    override func setUp() async throws {
+        coordinator = await MockCredentialCoordinator()
+    }
+
+    override func tearDown() async throws {
+        coordinator = nil
+    }
+
+    /// Reproduces the original deadlock scenario: many concurrent async tasks
+    /// all calling synchronous Credential APIs that bridge to
+    /// `@CredentialActor` via `withIsolationSyncThrowing`.
+    ///
+    /// Without the custom executor, this test would hang/crash with thread
+    /// starvation (EXC_BAD_ACCESS / SIGTRAP) because `group.wait()` blocks
+    /// cooperative threads while the actor's Task needs one to run.
+    ///
+    /// With the custom executor, the actor work runs on a GCD queue,
+    /// so blocking cooperative threads is harmless.
+    func testConcurrentSyncBridgeFromAsyncContextDoesNotDeadlock() async throws {
+        // Use enough concurrent tasks to saturate the cooperative thread pool.
+        // The pool is typically sized to the number of CPU cores. Using a large
+        // multiplier ensures we exceed it even on high-core-count machines.
+        let taskCount = ProcessInfo.processInfo.activeProcessorCount * 4
+        let timeout: TimeInterval = 10.0
+
+        // Create credentials to work with
+        var credentials: [Credential] = []
+        for i in 0..<taskCount {
+            let token = Token.mockToken(id: "StarvationTest-\(i)")
+            let credential = await coordinator.credentialDataSource.credential(
+                for: token,
+                coordinator: coordinator
+            )
+            credentials.append(credential)
+        }
+
+        // Launch many concurrent tasks that all call sync APIs which use
+        // withIsolationSyncThrowing under the hood. If the custom executor
+        // is not in place, this will deadlock.
+        let completed = expectation(description: "All tasks completed")
+        completed.expectedFulfillmentCount = taskCount
+
+        for credential in credentials {
+            Task {
+                // This calls withIsolationSyncThrowing internally
+                try credential.remove()
+                completed.fulfill()
+            }
+        }
+
+        await fulfillment(of: [completed], timeout: timeout)
+    }
+
+    /// Verifies that calling `Credential.store()` (sync, via
+    /// `withIsolationSyncThrowing`) concurrently from many async tasks
+    /// does not deadlock.
+    func testConcurrentStoreFromAsyncContextDoesNotDeadlock() async throws {
+        let taskCount = ProcessInfo.processInfo.activeProcessorCount * 4
+        let timeout: TimeInterval = 10.0
+
+        await CredentialActor.run {
+            Credential.tokenStorage = MockTokenStorage()
+            Credential.credentialDataSource = MockCredentialDataSource()
+        }
+
+        let completed = expectation(description: "All store tasks completed")
+        completed.expectedFulfillmentCount = taskCount
+
+        for i in 0..<taskCount {
+            Task {
+                let token = Token.mockToken(id: "StoreTest-\(i)")
+                _ = try Credential.store(token)
+                completed.fulfill()
+            }
+        }
+
+        await fulfillment(of: [completed], timeout: timeout)
+
+        // Wait briefly for any deferred notifications to drain before resetting
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await CredentialActor.run {
+            Credential.resetToDefault()
+        }
+    }
+
+    /// Tests the exact crash scenario from the customer report:
+    /// `credential.revoke()` (async) internally calls `withIsolationSyncThrowing`
+    /// to remove the credential from storage after revoking on the server.
+    ///
+    /// Multiple concurrent revoke calls from async contexts would exhaust the
+    /// cooperative pool without the custom executor.
+    func testConcurrentRevokeFromAsyncContextDoesNotDeadlock() async throws {
+        let taskCount = ProcessInfo.processInfo.activeProcessorCount * 4
+        let timeout: TimeInterval = 10.0
+
+        var credentials: [Credential] = []
+        for i in 0..<taskCount {
+            let token = Token.mockToken(
+                id: "RevokeTest-\(i)",
+                refreshToken: "refresh-\(i)"
+            )
+            let credential = await coordinator.credentialDataSource.credential(
+                for: token,
+                coordinator: coordinator
+            )
+
+            // Set up mock responses for revoke network calls
+            if let urlSession = credential.oauth2.session as? URLSessionMock {
+                urlSession.expect(
+                    "https://example.com/.well-known/openid-configuration",
+                    data: try data(from: .module,
+                                   for: "openid-configuration",
+                                   in: "MockResponses"),
+                    contentType: "application/json"
+                )
+                // Revoke endpoint for access token
+                urlSession.expect(
+                    "https://example.com/oauth2/v1/revoke",
+                    data: Data()
+                )
+                // Revoke endpoint for refresh token
+                urlSession.expect(
+                    "https://example.com/oauth2/v1/revoke",
+                    data: Data()
+                )
+            }
+
+            credentials.append(credential)
+        }
+
+        let completed = expectation(description: "All revoke tasks completed")
+        completed.expectedFulfillmentCount = taskCount
+
+        for credential in credentials {
+            Task {
+                // This is the exact pattern from the customer's crash:
+                // async function -> revoke() -> withIsolationSyncThrowing
+                try await credential.revoke(type: .all)
+                completed.fulfill()
+            }
+        }
+
+        await fulfillment(of: [completed], timeout: timeout)
+    }
+
+    /// Verifies that mixed concurrent access to multiple sync Credential APIs
+    /// from async contexts does not deadlock. This simulates a realistic app
+    /// scenario where different operations happen simultaneously.
+    func testMixedConcurrentOperationsDoNotDeadlock() async throws {
+        let operationsPerType = ProcessInfo.processInfo.activeProcessorCount * 2
+        let totalOperations = operationsPerType * 3
+        let timeout: TimeInterval = 15.0
+
+        await CredentialActor.run {
+            Credential.tokenStorage = MockTokenStorage()
+            Credential.credentialDataSource = MockCredentialDataSource()
+        }
+
+        let completed = expectation(description: "All mixed operations completed")
+        completed.expectedFulfillmentCount = totalOperations
+
+        // Store operations
+        for i in 0..<operationsPerType {
+            Task {
+                let token = Token.mockToken(id: "MixedStore-\(i)")
+                _ = try Credential.store(token)
+                completed.fulfill()
+            }
+        }
+
+        // allIDs reads (via withIsolationSync)
+        for _ in 0..<operationsPerType {
+            Task {
+                _ = Credential.allIDs
+                completed.fulfill()
+            }
+        }
+
+        // default getter reads (via withIsolationSync)
+        for _ in 0..<operationsPerType {
+            Task {
+                _ = Credential.default
+                completed.fulfill()
+            }
+        }
+
+        await fulfillment(of: [completed], timeout: timeout)
+
+        // Wait briefly for any deferred notifications to drain before resetting
+        try await Task.sleep(nanoseconds: 100_000_000)
+        await CredentialActor.run {
+            Credential.resetToDefault()
+        }
+    }
+}

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -54,7 +54,7 @@ final class OAuth2ClientTests: XCTestCase {
                            deviceSecret: nil,
                            context: Token.Context(configuration: self.configuration,
                                                   clientSettings: [ "client_id": "clientid", "refresh_token": "refresh" ]))
-        try await Credential.store(token)
+        try Credential.store(token)
         
         openIdConfiguration = try OpenIdConfiguration.jsonDecoder.decode(
             OpenIdConfiguration.self,

--- a/Tests/AuthFoundationTests/OAuth2ClientTests.swift
+++ b/Tests/AuthFoundationTests/OAuth2ClientTests.swift
@@ -54,7 +54,7 @@ final class OAuth2ClientTests: XCTestCase {
                            deviceSecret: nil,
                            context: Token.Context(configuration: self.configuration,
                                                   clientSettings: [ "client_id": "clientid", "refresh_token": "refresh" ]))
-        try Credential.store(token)
+        try await Credential.store(token)
         
         openIdConfiguration = try OpenIdConfiguration.jsonDecoder.decode(
             OpenIdConfiguration.self,


### PR DESCRIPTION
* Updates SDKVersion User-Agent processing to avoid using async UIDevice/WKInterfaceDevice functions.
* Introduce a GCD-based serial queue to the CredentialActor to avoid mixing task isolation implementations vis-á-vis  withIsolationSync. This fixes problems with thread starvation in busy applications or with low-core systems.
* Add tests to cover thread starvation to validate the fixes