### PR TITLE
User-Agent header missing in Release builds

### DIFF
--- a/Sources/AuthFoundation/Migration/Migration.swift
+++ b/Sources/AuthFoundation/Migration/Migration.swift
@@ -43,7 +43,7 @@ public final class Migration {
     nonisolated(unsafe) private(set) var registeredMigrators: [any SDKVersionMigrator]
 
     init(migrators: [any SDKVersionMigrator]? = nil) {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
         self.registeredMigrators = migrators ?? Self.defaultMigrators
     }
 

--- a/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
+++ b/Sources/AuthFoundation/OAuth2/OAuth2Client.swift
@@ -115,7 +115,7 @@ public final class OAuth2Client: UsesDelegateCollection {
     ///   - configuration: The pre-formed configuration for this client.
     ///   - session: Optional URLSession to use for network requests.
     public init(_ configuration: Configuration, session: (any URLSessionProtocol)? = nil) {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
 
         // Ensure the time coordinator is properly initialized
         _ = Date.coordinator

--- a/Sources/AuthFoundation/User Management/Credential.swift
+++ b/Sources/AuthFoundation/User Management/Credential.swift
@@ -29,14 +29,14 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     /// This can be used as a convenience to store a user's token within storage, and to access the user in a safe way. If the user's token isn't stored, this will automatically store the token for later use.
     public static var `default`: Credential? {
         get {
-            assert(SDKVersion.authFoundation != nil)
+            _ = SDKVersion.authFoundation
 
             return CredentialActor.sync {
                 TaskData.coordinator.default
             }
         }
         set {
-            assert(SDKVersion.authFoundation != nil)
+            _ = SDKVersion.authFoundation
 
             CredentialActor.sync {
                 TaskData.coordinator.default = newValue
@@ -46,7 +46,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     
     /// Lists all users currently stored within the user's application.
     public static var allIDs: [String] {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
 
         return CredentialActor.sync {
             TaskData.coordinator.allIDs
@@ -72,7 +72,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     ///   - authenticationContext: Optional `LAContext` to use when retrieving credentials, on systems that support it.
     /// - Returns: Credential matching the ID.
     public static func with(id: String, prompt: String? = nil, authenticationContext: (any TokenAuthenticationContext)? = nil) throws -> Credential? {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
 
         return try CredentialActor.sync {
             try TaskData.coordinator.with(id: id,
@@ -100,7 +100,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
     ///   - authenticationContext: Optional `LAContext` to use when retrieving credentials, on systems that support it.
     /// - Returns: Collection of credentials that matches the given expression.
     public static func find(where expression: @Sendable @escaping (Token.Metadata) -> Bool, prompt: String? = nil, authenticationContext: (any TokenAuthenticationContext)? = nil) throws -> [Credential] {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
 
         return try CredentialActor.sync {
             try TaskData.coordinator.find(where: expression,
@@ -127,7 +127,7 @@ public final class Credential: Equatable, OAuth2ClientDelegate {
                              tags: [String: String] = [:],
                              security options: [Security] = Security.standard
     ) throws -> Credential {
-        assert(SDKVersion.authFoundation != nil)
+        _ = SDKVersion.authFoundation
 
         return try CredentialActor.sync {
             try TaskData.coordinator.store(token: token, tags: tags, security: options)

--- a/Sources/BrowserSignin/BrowserSignin.swift
+++ b/Sources/BrowserSignin/BrowserSignin.swift
@@ -311,7 +311,7 @@ public final class BrowserSignin {
     ///   - loginFlow: Authorization code flow instance for signing in to this client.
     ///   - logoutFlow: Session sign out flow to use when signing out from this client.
     public init(loginFlow: AuthorizationCodeFlow, logoutFlow: SessionLogoutFlow?) {
-        assert(SDKVersion.browserSignin != nil)
+        _ = SDKVersion.browserSignin
 
         self.signInFlow = loginFlow
         self.signOutFlow = logoutFlow

--- a/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/AuthorizationCodeFlow.swift
@@ -145,7 +145,7 @@ public actor AuthorizationCodeFlow: AuthenticationFlow {
     init(verifiedClient client: OAuth2Client,
          additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Authentication/DeviceAuthorizationFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/DeviceAuthorizationFlow.swift
@@ -121,7 +121,7 @@ public actor DeviceAuthorizationFlow: AuthenticationFlow {
     ///   - additionalParameters: Optional additional query string parameters you would like to supply to the authorization server.
     public init(client: OAuth2Client,
                 additionalParameters: [String: any APIRequestArgument]? = nil) {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Authentication/JWTAuthorizationFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/JWTAuthorizationFlow.swift
@@ -76,7 +76,7 @@ public actor JWTAuthorizationFlow: AuthenticationFlow {
     public init(client: OAuth2Client,
                 additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Authentication/ResourceOwnerFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/ResourceOwnerFlow.swift
@@ -79,7 +79,7 @@ public actor ResourceOwnerFlow: AuthenticationFlow {
     public init(client: OAuth2Client,
                 additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Authentication/SessionTokenFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/SessionTokenFlow.swift
@@ -87,7 +87,7 @@ public actor SessionTokenFlow: AuthenticationFlow {
             throw OAuth2Error.redirectUriRequired
         }
         
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Authentication/TokenExchangeFlow.swift
+++ b/Sources/OAuth2Auth/Authentication/TokenExchangeFlow.swift
@@ -102,7 +102,7 @@ public actor TokenExchangeFlow: AuthenticationFlow {
     public init(client: OAuth2Client,
                 additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OAuth2Auth/Logout/SessionLogoutFlow.swift
+++ b/Sources/OAuth2Auth/Logout/SessionLogoutFlow.swift
@@ -104,7 +104,7 @@ public actor SessionLogoutFlow: LogoutFlow {
     public init(client: OAuth2Client,
                 additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oauth2 != nil)
+        _ = SDKVersion.oauth2
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Sources/OktaDirectAuth/DirectAuthFlow.swift
+++ b/Sources/OktaDirectAuth/DirectAuthFlow.swift
@@ -369,7 +369,7 @@ public actor DirectAuthenticationFlow: AuthenticationFlow {
                 supportedGrants grantTypes: [GrantType] = .directAuth,
                 additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.directAuth != nil)
+        _ = SDKVersion.directAuth
 
         self.client = client
         self.supportedGrantTypes = grantTypes
@@ -379,7 +379,7 @@ public actor DirectAuthenticationFlow: AuthenticationFlow {
     }
     
     public init(client: OAuth2Client, additionalParameters: [String: any APIRequestArgument]?) throws {
-        assert(SDKVersion.directAuth != nil)
+        _ = SDKVersion.directAuth
 
         self.client = client
         self.supportedGrantTypes = .directAuth

--- a/Sources/OktaIdxAuth/InteractionCodeFlow.swift
+++ b/Sources/OktaIdxAuth/InteractionCodeFlow.swift
@@ -101,7 +101,7 @@ public actor InteractionCodeFlow: AuthenticationFlow {
     init(verifiedClient client: OAuth2Client,
          additionalParameters: [String: any APIRequestArgument]? = nil)
     {
-        assert(SDKVersion.oktaIdx != nil)
+        _ = SDKVersion.oktaIdx
 
         self.client = client
         self.additionalParameters = additionalParameters

--- a/Tests/AuthFoundationTests/SDKVersionRegistrationTests.swift
+++ b/Tests/AuthFoundationTests/SDKVersionRegistrationTests.swift
@@ -14,12 +14,6 @@ import XCTest
 @testable import AuthFoundation
 
 final class SDKVersionRegistrationTests: XCTestCase {
-    /// Regression test for #254 — User-Agent header missing in Release builds.
-    ///
-    /// `SDKVersion.userAgent` is populated as a side effect of evaluating the
-    /// lazy `static let` registration in each `Version+*.swift`. That evaluation
-    /// must run in every build configuration. This test asserts the contract
-    /// after constructing an `OAuth2Client`.
     func testOAuth2ClientInitPopulatesUserAgent() throws {
         let client = OAuth2Client(
             issuerURL: try XCTUnwrap(URL(string: "https://example.okta.com/oauth2/default")),

--- a/Tests/AuthFoundationTests/SDKVersionRegistrationTests.swift
+++ b/Tests/AuthFoundationTests/SDKVersionRegistrationTests.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2026-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import AuthFoundation
+
+final class SDKVersionRegistrationTests: XCTestCase {
+    /// Regression test for #254 — User-Agent header missing in Release builds.
+    ///
+    /// `SDKVersion.userAgent` is populated as a side effect of evaluating the
+    /// lazy `static let` registration in each `Version+*.swift`. That evaluation
+    /// must run in every build configuration. This test asserts the contract
+    /// after constructing an `OAuth2Client`.
+    func testOAuth2ClientInitPopulatesUserAgent() throws {
+        let client = OAuth2Client(
+            issuerURL: try XCTUnwrap(URL(string: "https://example.okta.com/oauth2/default")),
+            clientId: "test-client-id",
+            scope: ["openid"]
+        )
+        _ = client
+
+        XCTAssertFalse(SDKVersion.userAgent.isEmpty,
+                       "User-Agent must be populated after OAuth2Client init in any build configuration.")
+        XCTAssertTrue(SDKVersion.userAgent.contains("okta-authfoundation-swift/"),
+                      "User-Agent must include the AuthFoundation SDK marker; got '\(SDKVersion.userAgent)'.")
+    }
+}


### PR DESCRIPTION
## Summary

`SDKVersion.userAgent` is populated as a side effect of evaluating the lazy `static let` registration in each `Version+*.swift`. Every dereference site was spelled `assert(SDKVersion.X != nil)` — but Swift's `assert(_:)` takes its condition as `@autoclosure`, which the optimizer strips entirely in `-O` (Release) builds. In Release/TestFlight builds the lazies never fire, `SDKVersion._userAgent` stays the empty string, and every outgoing SDK request goes out with an empty `User-Agent` header.

This reproduces exactly as reported: present in Debug, missing in Release. For at least one customer (MGM Resorts), the header-less traffic is being flagged as bot activity by their WAF.

Replaces the 19 `assert(SDKVersion.X != nil)` triggers across 13 files with `_ = SDKVersion.X`, so the lazy registration fires unconditionally regardless of build configuration. Same registration mechanism — only the trigger moves out of an `@autoclosure`.

Adds `Tests/AuthFoundationTests/SDKVersionRegistrationTests.swift` to pin the contract. Verified locally: fails on unmodified `master` under `swift test -c release`, passes after this change. Full suite (395 tests) passes in both Debug and Release after the fix.

## Credit

This is a cherry-pick of the fix and diagnosis from @RicardoKoch's #277, with a follow-up commit trimming the new test's doc comment to match this repo's style. Opening as a fresh PR against current `master` (superseding #277) since that PR's CI never ran and it needed review from an Okta maintainer.

Fixes #254.