### PR TITLE
Fix WebAuthn/Duo credentials merge bug (OKTA-1209004)

### DIFF
--- a/Sources/OktaIdxAuth/Internal/Extensions/IDXRemediation+Extensions.swift
+++ b/Sources/OktaIdxAuth/Internal/Extensions/IDXRemediation+Extensions.swift
@@ -69,12 +69,14 @@ extension Remediation.Form.Field {
             if let form = self.form,
                !form.allFields.isEmpty
             {
+                var nestedJSON = JSON([:])
                 for field in form.allFields {
                     guard let nestedResult = try field.formValue else {
                         continue
                     }
-                    json[name] = nestedResult
+                    nestedJSON.value += nestedResult
                 }
+                json[name] = nestedJSON.value
             }
             
             // Named form values that consist of multiple child options

--- a/Tests/OktaIdxAuthTests/IDXExtractFormValueTests.swift
+++ b/Tests/OktaIdxAuthTests/IDXExtractFormValueTests.swift
@@ -87,6 +87,54 @@ class IDXExtractFormValueTests: XCTestCase {
         XCTAssertEqual(result["credentials"], .object(["passcode": "password"]))
     }
 
+    // OKTA-1209004: A named field with a nested `form` containing multiple
+    // child fields (e.g. WebAuthn's `credentials` object) must merge all of
+    // its children into a single object, not overwrite with only the last one.
+    func testNestedWithMultipleChildValues() throws {
+        let form = try XCTUnwrap(Form(fields: [
+            Form.Field(name: "stateHandle",
+                      value: "abcEasyAs123",
+                      visible: false,
+                      mutable: false,
+                      required: true,
+                      secret: false),
+            Form.Field(name: "credentials",
+                      type: "object",
+                      visible: true,
+                      mutable: true,
+                      required: true,
+                      secret: false,
+                      form: Form(fields: [
+                        Form.Field(name: "authenticatorData",
+                                  visible: true,
+                                  mutable: true,
+                                  required: true,
+                                  secret: false),
+                        Form.Field(name: "clientData",
+                                  visible: true,
+                                  mutable: true,
+                                  required: true,
+                                  secret: false),
+                        Form.Field(name: "signatureData",
+                                  visible: true,
+                                  mutable: true,
+                                  required: true,
+                                  secret: false)
+                      ]))
+        ]))
+        form["credentials.authenticatorData"]?.value = "IMIVPkdt3y..."
+        form["credentials.clientData"]?.value = "eyJ0e..."
+        form["credentials.signatureData"]?.value = "MEUC..."
+
+        let result = try form.formValue
+        XCTAssertEqual(result["stateHandle"], "abcEasyAs123")
+        XCTAssertEqual(result["credentials"], [
+            "authenticatorData": "IMIVPkdt3y...",
+            "clientData": "eyJ0e...",
+            "signatureData": "MEUC..."
+        ])
+    }
+
     func testNestedWithNestedDefaults() throws {
         let nestedForm = Form.Field(label: "Security Question",
                                    visible: true,


### PR DESCRIPTION
## Summary
- Adds a regression test (`testNestedWithMultipleChildValues`) proving `Remediation.Form.Field.formValue` drops sibling fields when a named field's nested `form` has 2+ children — e.g. WebAuthn's `credentials` object (`authenticatorData`/`clientData`/`signatureData`), which is the root cause of [OKTA-1209004](https://oktainc.atlassian.net/browse/OKTA-1209004).
- Cherry-picks the fix from #282 (commit 634cea875): accumulate nested child values into a separate `nestedJSON` object via `+=` merge, then assign once, instead of overwriting `json[name]` on every loop iteration.

## Root cause
In `IDXRemediation+Extensions.swift`, the "named field with nested form" branch looped over each child field and did `json[name] = nestedResult` every iteration — each nested child's own `{childName: value}` wrapper replaced the previous one, so only the last-processed child survived. When the last child happened to be unset (e.g. optional `userHandle` on the autofill UI challenge), the result was an empty `credentials: {}`, matching the customer's HAR capture on Crate & Barrel's org.

This affects:
- `WebAuthnAuthenticationCapability` (passkey/WebAuthn auth) — confirmed via mock fixture (3 fields)
- `WebAuthnRegistrationCapability` (passkey/WebAuthn registration) — confirmed via mock fixture (2 fields)
- `DuoCapability` — only sets a single field today, so not currently exercised by this bug, but not covered by a fixture-based test either
